### PR TITLE
Trim for HTML else jQuery treats it as expression.

### DIFF
--- a/app/assets/javascripts/koi/jquery/nestedFields.js
+++ b/app/assets/javascripts/koi/jquery/nestedFields.js
@@ -122,7 +122,7 @@
       contents = unescape_html_tags(contents);
     }
 
-    var newItem = $(contents.replace(regexp, newId));
+    var newItem = $(contents.replace(regexp, newId).trim ());
     newItem.attr('data-new-record', true);
     newItem.attr('data-record-id', newId);
 


### PR DESCRIPTION
This was causing the template inserted by nestedFields to be interpreted as CSS.
