### PR TITLE
Relativisation of web fonts to work with SSL

### DIFF
--- a/app/views/layouts/koi/html.html.erb
+++ b/app/views/layouts/koi/html.html.erb
@@ -13,8 +13,8 @@
     <%= js_data if defined?(js_data) %><!-- FIXME: helper isn't loaded by DeviseController -->
 
     <!-- style -->
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans+Condensed:700' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans+Condensed:700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
     <%= stylesheet_link_tag "koi/application" %>
     <%= yield(:stylesheets) %>
 


### PR DESCRIPTION
Admin fonts aren't working on beta.medehealth.com.au.

I'm not certain, but it seems like this might be why...
