### PR TITLE
Allow for label_method in simple_form association parameters.

### DIFF
--- a/app/views/koi/admin_crud/_form_field_association.html.erb
+++ b/app/views/koi/admin_crud/_form_field_association.html.erb
@@ -1,3 +1,8 @@
-<%= f.association attr.to_sym, as: resource_class.crud.find(:fields, attr, :as) unless resource.new_record? %>
+<% unless resource.new_record? %>
 
-<%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>
+  <%= f.association attr.to_sym, as: (resource_class.crud.find :fields, attr, :as),
+                       label_method: (resource_class.crud.find :fields, attr, :as or :to_s) %>
+
+  <%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>
+
+<% end %>


### PR DESCRIPTION
Nice to be able to override label_method, and `to_s` is a better default than whatever simple_form uses (it varies...).

Can't figure out why it's only allowed to be displayed if `new_record?` though?
