### PR TITLE
Fix for front-end link resolution in /admin

### DIFF
--- a/lib/has_navigation/has_navigation/has_navigation.rb
+++ b/lib/has_navigation/has_navigation/has_navigation.rb
@@ -19,7 +19,7 @@ module HasNavigation
       resource_nav_item = self.resource_nav_item.blank? ? ResourceNavItem.new : self.resource_nav_item
       resource_nav_item.attributes = options.merge(title: (self.try(:title) || "#{self.class} - #{self.id}"),
                                                    url: polymorphic_path(self),
-                                                   admin_url: "/admin#{edit_polymorphic_path(self)}",
+                                                   admin_url: edit_polymorphic_path([:admin, self]),
                                                    setting_prefix: respond_to?(:settings_prefix) ? settings_prefix : nil)
       resource_nav_item
     end


### PR DESCRIPTION
Getting errors in admin due to certain front-end routes not working, e.g. `edit_*`.

I believe this fixes the issue.
