### PR TITLE
Updated version of Koi generated in Gemfile.

### DIFF
--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -19,7 +19,7 @@ gem 'koi_config'                , :git => 'git://github.com/katalyst/koi_config.
 
 # Koi CMS
 gem 'koi'                       , :git => 'git://github.com/katalyst/koi.git',
-                                  :branch => 'v1.0.0.beta'
+                                  :branch => 'v1.0.0'
 
 # Bowerbird
 gem 'bowerbird_v2'              , :git => 'git@github.com:katalyst/bowerbird_v2.git'


### PR DESCRIPTION
Koi template was generating `beta` dependency. Now v1.0.0.
