### PR TITLE
Allow for HTML in module menu, e.g. &nbsp;

### DIFF
--- a/app/views/layouts/koi/_navigation.html.erb
+++ b/app/views/layouts/koi/_navigation.html.erb
@@ -5,7 +5,7 @@
     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Module <b class="caret"></b> </a>
     <ul class="dropdown-menu">
       <% Koi::Menu.items.each do |key, value| %>
-        <%= content_tag :li, link_to(key, value) %>
+        <%= content_tag :li, link_to(raw(key), value) %>
       <% end %>
     </ul>
   </li>


### PR DESCRIPTION
Minor tweak to allow e.g. indentable module menu.
