### PR TITLE
Fix for msword assets not displaying correctly on the front end.

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,10 +1,9 @@
 class AssetsController < Koi::CrudController
 
   def show
-    respond_to do |format|
-      format.html { super }
-      format.all { redirect_to data_path resource.data }
-    end
+    return super if params[:format].blank?
+    return super if /(x|ht)ml?|js/i === params[:format]
+    return redirect_to data_path resource.data
   end
 
   def data_path data

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -5,4 +5,3 @@
 # Mime::Type.register_alias "text/html", :iphone
 
 Mime::Type.register_alias "text/x-component", :htc
-


### PR DESCRIPTION
For some reason the format switch wasn't working for A PARTICULAR doc. No idea why.

This should be a little bit more robust, if not a little uggers.

This is the required behaviour anyway - to return the actual asset if a more file-like extension is provided.
