### PR TITLE
fixed several gem versions that were holding up bootstrapping

### DIFF
--- a/koi.gemspec
+++ b/koi.gemspec
@@ -117,5 +117,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'pry-rails'
   s.add_development_dependency 'web-console', '~> 2.0'
-  s.add_development_dependency 'spring'
 end

--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -321,10 +321,10 @@ END
 # Setup koi initializer to define admin menu and other koi related settings
 create_file 'config/initializers/koi.rb', <<-END
 Koi::Menu.items = {
-  "Modules": {
+  "Modules" => {
 
   },
-  "Advanced": {
+  "Advanced" => {
     "Admins"       => "/admin/site_users",
     "URL History"  => "/admin/friendly_id_slugs",
     "URL Rewriter" => "/admin/url_rewrites"

--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -22,7 +22,7 @@ END
 gem "jquery-ui-rails"
 
 # Airbrake
-gem "airbrake"
+gem "airbrake"                  , '4.3'
 
 # Nested fields
 gem 'awesome_nested_fields'     , github: 'katalyst/awesome_nested_fields'
@@ -32,7 +32,7 @@ gem 'koi_config'                , github: 'katalyst/koi_config'
 
 # Koi CMS
 gem 'koi'                       , github: 'katalyst/koi',
-                                  branch: 'v2.0.0'
+                                  branch: 'v2.2.0'
 
 # Compass
 gem 'compass'                   , "~> 1.0.0"
@@ -40,9 +40,9 @@ gem 'compass'                   , "~> 1.0.0"
 gem 'compass-rails'             , "~> 2.0.2"
 
 # i18n ActiveRecord backend
-gem 'i18n-active_record'        , github: 'svenfuchs/i18n-active_record',
-                                  branch: 'master',
-                                  require: 'i18n/active_record'
+gem 'i18n-active_record',   github: 'svenfuchs/i18n-active_record',
+                            require: 'i18n/active_record',
+                            ref: 'b26c2e62e32df2f3b9ae42083647725b7ecfdff0'
 
 gem 'unicorn'
 
@@ -322,7 +322,7 @@ END
 create_file 'config/initializers/koi.rb', <<-END
 Koi::Menu.items = {
   "Modules": {
-    
+
   },
   "Advanced": {
     "Admins"       => "/admin/site_users",

--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -44,6 +44,8 @@ gem 'i18n-active_record',   github: 'svenfuchs/i18n-active_record',
                             require: 'i18n/active_record',
                             ref: 'b26c2e62e32df2f3b9ae42083647725b7ecfdff0'
 
+gem 'active_model_serializers'
+
 gem 'unicorn'
 
 gem 'newrelic_rpm'


### PR DESCRIPTION
- Removed Spring, as no one uses it currently, and it causes various errors
- Updated branch of koi written to the gemfile in bootstrap process
- Specified specific version of Airbrake gem which we know to be stable (used on ysa-v2)
- Specific a specific commit of i18n-active_record gem that we believe to be stable