### PR TITLE
Feature/smart field types

### DIFF
--- a/app/helpers/koi/icon_helper.rb
+++ b/app/helpers/koi/icon_helper.rb
@@ -35,7 +35,9 @@ module Koi::IconHelper
   #
   def attachment_image_tag(attachment, options={})
     options.reverse_merge!(width: 100, height: 100)
-    image_tag((document?(attachment.ext) ? document_icon(attachment) : image_thumbnail(attachment, options)), options)
+    is_image  = attachment.app.name == :image
+    thumbnail = is_image ? image_thumbnail(attachment, options) : document_icon(attachment)
+    image_tag(thumbnail, options)
   end
 
   # Return a unique ID.

--- a/lib/generators/koi.rb
+++ b/lib/generators/koi.rb
@@ -28,7 +28,7 @@ module Koi
       def process_attributes
         args_for_c_m.each do |arg|
           if arg.include?(':')
-            @model_attributes << Rails::Generators::GeneratedAttribute.new(*arg.split(':'))
+            @model_attributes << Rails::Generators::GeneratedAttribute.parse(arg)
           end
         end
       end
@@ -36,57 +36,57 @@ module Koi
       #make the field type for crud
       # i.e. banner_image: { type: :image }
       def make_field_type(attr, index)
-        field_type    = guess_field_type(attr.name, attr.type)
+        field_type    = guess_field_type(attr)
         whitespace    = whitespace_for_field(attr)
         field_name    = attr.name.chomp('_uid').chomp('_id')
         is_last_field = index === @model_attributes.length-1
-        "#{field_name}:#{whitespace} #{field_type}#{',' unless is_last_field}\n\s\s\s\s\s\s\s\s\s\s\s"
+        "#{field_name}:#{whitespace} #{field_type}#{',' unless is_last_field}#{' # override this' if attr.polymorphic?}\n\s\s\s\s\s\s\s\s\s\s\s"
       end
 
-      def guess_field_type(name, data_type)
-        if field_is_rich_text?(name, data_type)
+      def guess_field_type(attr)
+        if field_is_rich_text?(attr)
           '{ type: :rich_text }'
-        elsif field_is_image?(name, data_type)
+        elsif field_is_image?(attr)
           '{ type: :image }'
-        elsif field_is_file?(name, data_type)
+        elsif field_is_file?(attr)
           '{ type: :file }'
-        elsif data_type == 'boolean'
-          '{ type: :boolean }'
-        elsif field_is_enum?(name, data_type)
-          "{ type: :select, data: #{name.pluralize.upcase}.invert }"
-        elsif field_is_association?(name, data_type)
+        elsif field_is_enum?(attr)
+          "{ type: :select, data: #{attr.name.pluralize.upcase}.invert }"
+        elsif field_is_association?(attr)
           "{ type: :association }"
-        elsif data_type == 'date'
+        elsif attr.type == :boolean
+          '{ type: :boolean }'
+        elsif attr.type == :date
           '{ type: :date }'
-        elsif data_type == 'datetime'
+        elsif attr.type == :datetime
           '{ type: :datetime }'
         else
           '{ type: :default }'
         end
       end
 
-      def field_is_rich_text?(name, data_type)
-        data_type == 'text' && name.exclude?('embed') && name.exclude?('short')
+      def field_is_rich_text?(attr)
+        attr.type == :text && attr.name.exclude?('embed') && attr.name.exclude?('short')
       end
 
-      def field_is_enum?(name, data_type)
-        data_type == 'integer' && (name.include?('status') || name.include?('type'))
+      def field_is_enum?(attr)
+        attr.type == :integer && (attr.name.include?('status') || attr.name.include?('type'))
       end
 
-      def field_is_image?(name, data_type)
-        name.include?('_uid') && image_names.any?{ |image_name| name.include?(image_name) }
+      def field_is_image?(attr)
+        attr.name.include?('_uid') && image_names.any?{ |image_name| attr.name.include?(image_name) }
       end
 
-      def field_is_file?(name, data_type)
-        name.include?('_uid') && doc_names.any?{ |doc_name| name.include?(doc_name) }
+      def field_is_file?(attr)
+        attr.name.include?('_uid') && doc_names.any?{ |doc_name| attr.name.include?(doc_name) }
       end
 
-      def field_is_url?(name, data_type)
-        name.include?('url') || name.include?('link')
+      def field_is_url?(attr)
+        attr.name.include?('url') || attr.name.include?('link')
       end
 
-      def field_is_association?(name, data_type)
-        name.include?('_id') || data_type == 'belongs_to'
+      def field_is_association?(attr)
+        attr.name.include?('_id') || attr.reference?
       end
 
       # for keeping whitespace nice in form field type generation
@@ -102,12 +102,13 @@ module Koi
       end
 
       def crud_field_list
-        @model_attributes.map{|attr| attr.name.chomp('_uid').chomp('_id').to_sym }
+        @model_attributes.reject(&:polymorphic?)
+                         .map{|attr| attr.name.chomp('_uid').chomp('_id').to_sym }
       end
 
       def crud_csv_field_list
         #reject fields that are files or images and collects the attribute names
-        @model_attributes.reject{ |attr| field_is_image?(attr.name, attr.type) || field_is_file?(attr.name, attr.type) }
+        @model_attributes.reject{ |attr| field_is_image?(attr) || field_is_file?(attr) }
                          .map{ |attr| attr.name.chomp('_id').to_sym }
       end
 
@@ -120,11 +121,11 @@ module Koi
       end
 
       def file_attributes
-        @model_attributes.select{ |attr| field_is_file?(attr.name, attr.type) }
+        @model_attributes.select{ |attr| field_is_file?(attr) }
       end
 
       def image_attributes
-        @model_attributes.select{ |attr| field_is_image?(attr.name, attr.type) }
+        @model_attributes.select{ |attr| field_is_image?(attr) }
       end
 
 
@@ -132,12 +133,12 @@ module Koi
       # RENDER METHODS FOR FIELD CONFIG
       #
       # these methods are used to generate dragonfly accessors, validation for images/files,
-      # validation for urls, enum for statuses, and belongs_to associations
+      # validation for urls/booleans, enum for statuses, and belongs_to associations
       #
 
       def render_enums
         # get likely enum attributes
-        enums = model_attributes.select{ |attr| field_is_enum?(attr.name, attr.type) }
+        enums = model_attributes.select{ |attr| field_is_enum?(attr) }
 
         # for each enum, create a constant, an enum field, and validation
         enums.map{ |attr|
@@ -151,7 +152,7 @@ module Koi
       end
 
       def render_images
-        images = model_attributes.select{ |attr| field_is_image?(attr.name, attr.type) }
+        images = model_attributes.select{ |attr| field_is_image?(attr) }
         images.map{ |attr|
           <<-code
   dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :image
@@ -162,7 +163,7 @@ module Koi
       end
 
       def render_files
-        files = model_attributes.select{ |attr| field_is_file?(attr.name, attr.type) }
+        files = model_attributes.select{ |attr| field_is_file?(attr) }
         files.map{ |attr|
           <<-code
   dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :file
@@ -174,7 +175,7 @@ module Koi
 
       def render_urls
         # get likely url fields
-        urls = model_attributes.select{ |attr| field_is_url?(attr.name, attr.type) }
+        urls = model_attributes.select{ |attr| field_is_url?(attr) }
         urls.map{ |attr|
           <<-code
   validates :#{attr.name}, format: { with: URI::regexp, message: \"must be a valid url (including http:// or https://)\" }
@@ -184,10 +185,20 @@ module Koi
       end
 
       def render_associations
-        associations = model_attributes.select{ |attr| field_is_association?(attr.name, attr.type) }
+        associations = model_attributes.select{ |attr| field_is_association?(attr) }
         associations.map{ |attr|
           <<-code
-  belongs_to :#{attr.name.chomp('_id')}
+  belongs_to :#{attr.name.chomp('_id')}#{", polymorphic: true" if attr.polymorphic?}
+
+          code
+        }.join
+      end
+
+      def render_booleans
+        booleans = model_attributes.select{ |attr| attr.type.eql?('boolean') }
+        booleans.map{ |attr|
+          <<-code
+  validates :#{attr.name}, inclusion: { in: [true, false], message: "Can't be blank" }
 
           code
         }.join

--- a/lib/generators/koi.rb
+++ b/lib/generators/koi.rb
@@ -36,7 +36,11 @@ module Koi
       #make the field type for crud
       # i.e. banner_image: { type: :image }
       def make_field_type(attr, index)
-        "#{attr.name.chomp('_uid')}:#{whitespace_for_field(attr)} #{guess_field_type(attr.name, attr.type)}#{',' if index != @model_attributes.length-1}\n\s\s\s\s\s\s\s\s\s\s\s"
+        field_type    = guess_field_type(attr.name, attr.type)
+        whitespace    = whitespace_for_field(attr)
+        field_name    = attr.name.chomp('_uid')
+        is_last_field = index === @model_attributes.length-1
+        "#{field_name}:#{whitespace} #{field_type}#{',' unless is_last_field}\n\s\s\s\s\s\s\s\s\s\s\s"
       end
 
       def guess_field_type(name, data_type)
@@ -75,9 +79,16 @@ module Koi
         name.include?('url') || name.include?('link')
       end
 
-      #for keeping whitespace nice in form field type generation
+      # for keeping whitespace nice in form field type generation
+      # e.g.
+      #          something: { type: string },
+      #          file:      { type: :file },
+      #          my_url:    { type: :string }
       def whitespace_for_field(attr)
-        "\s"*(@model_attributes.max_by{|attr|attr.name.chomp('_uid').length}.name.chomp('_uid').length-attr.name.chomp('_uid').length)
+        longest_attribute_name = @model_attributes.max_by{ |attr| attr.name.chomp('_uid').length }.name.chomp('_uid')
+        current_attribute_name = attr.name.chomp('_uid')
+        whitespace_needed      = longest_attribute_name.length - current_attribute_name.length
+        "\s" * whitespace_needed
       end
 
       def crud_field_list
@@ -85,7 +96,7 @@ module Koi
       end
 
       def crud_csv_field_list
-        #reject fields that are files or images
+        #reject fields that are files or images and collects the attribute names
         @model_attributes.reject{ |attr| field_is_image?(attr.name, attr.type) || field_is_file?(attr.name, attr.type) }
                          .map{ |attr| attr.name.to_sym }
       end

--- a/lib/generators/koi.rb
+++ b/lib/generators/koi.rb
@@ -33,6 +33,63 @@ module Koi
         end
       end
 
+      #make the field type for crud
+      # i.e. banner_image: { type: :image }
+      def make_field_type(attr, index)
+        "#{attr.name.chomp('_uid')}:#{whitespace_for_field(attr)} #{guess_field_type(attr.name, attr.type)}#{',' if index != @model_attributes.length-1}\n\s\s\s\s\s\s\s\s\s\s\s"
+      end
+
+      def guess_field_type(name, data_type)
+        if data_type == 'text'
+          '{ type: :rich_text }'
+        elsif field_is_image?(name, data_type)
+          '{ type: :image }'
+        elsif field_is_file?(name, data_type)
+          '{ type: :file }'
+        elsif data_type == 'boolean'
+          '{ type: :boolean }'
+        elsif field_is_enum?(name, data_type)
+          "{ type: :select, data: #{name.pluralize.upcase}.invert }"
+        else
+          '{ type: :string }'
+        end
+      end
+
+      def field_is_enum?(name, data_type)
+        data_type == 'integer' && name.include?('status')
+      end
+
+      def field_is_image?(name, data_type)
+        name.include?('_uid') && image_names.any?{ |image_name| name.include?(image_name) }
+      end
+
+      def field_is_file?(name, data_type)
+        name.include?('_uid') && doc_names.any?{ |doc_name| name.include?(doc_name) }
+      end
+
+      #for keeping whitespace nice in form field type generation
+      def whitespace_for_field(attr)
+        "\s"*(@model_attributes.max_by{|attr|attr.name.chomp('_uid').length}.name.chomp('_uid').length-attr.name.chomp('_uid').length)
+      end
+
+      def crud_field_list
+        @model_attributes.map{|attr| attr.name.chomp('_uid').to_sym }
+      end
+
+      def crud_csv_field_list
+        #reject fields that are files or images
+        @model_attributes.reject{ |attr| field_is_image?(attr.name, attr.type) || field_is_file?(attr.name, attr.type) }
+                         .map{ |attr| attr.name.to_sym }
+      end
+
+      def image_names
+        ['image', 'banner', 'thumb', 'logo', 'tile']
+      end
+
+      def doc_names
+        ['file', 'document', 'pdf', 'attachment']
+      end
+
     end
   end
 end

--- a/lib/generators/koi.rb
+++ b/lib/generators/koi.rb
@@ -208,6 +208,30 @@ module Koi
       # END FIELD CONFIG RENDER METHODS
       #
 
+      #
+      # CONTROLLER CONFIG
+      #
+
+      def make_permitted_params
+        <<-code
+        
+  def permitted_params
+    params.permit(#{class_name.underscore}: #{crud_field_list + file_and_image_params})
+  end
+        code
+      end
+
+      # for permitted params like :retained_image and :remove_image
+      def file_and_image_params
+        (file_attributes+image_attributes).map do |attr|
+          name = attr.name.chomp('_uid')
+          [:"retained_#{name}", :"remove_#{name}"]
+        end.flatten
+      end
+
+      #
+      # END CONTROLLER CONFIG
+      #
 
     end
   end

--- a/lib/generators/koi.rb
+++ b/lib/generators/koi.rb
@@ -78,7 +78,7 @@ module Koi
       end
 
       def field_is_file?(attr)
-        attr.name.include?('_uid') && doc_names.any?{ |doc_name| attr.name.include?(doc_name) }
+        attr.name.include?('_uid') && !field_is_image?(attr)
       end
 
       def field_is_url?(attr)

--- a/lib/generators/koi/admin_controller/templates/migration_template.rb
+++ b/lib/generators/koi/admin_controller/templates/migration_template.rb
@@ -2,7 +2,7 @@ class Create<%= class_name.pluralize.delete('::') %> < ActiveRecord::Migration
   def change
     create_table :<%= table_name %> do |t|
 <%- model_attributes.each do |attribute| -%>
-      t.<%= attribute.type %> :<%= attribute.name %>
+      t.<%= attribute.type %> :<%= attribute.name %><%= ", polymorphic: true" if attribute.polymorphic? %><%= ", index: true" if attribute.has_index? %>
 <%- end -%>
 <%- if @versioned -%>
       t.string :aasm_state
@@ -17,4 +17,3 @@ class Create<%= class_name.pluralize.delete('::') %> < ActiveRecord::Migration
     add_index :<%= table_name %>, :slug, :unique => true
   end
 end
-

--- a/lib/generators/koi/admin_controller/templates/model_template.rb
+++ b/lib/generators/koi/admin_controller/templates/model_template.rb
@@ -11,6 +11,7 @@ class <%= class_name %> < ActiveRecord::Base
 <%= render_images %>
 <%= render_files %>
 <%= render_urls %>
+<%= render_booleans %>
   crud.config do
     fields <%- model_attributes.each_with_index do |attr, i| -%>
   <%= make_field_type(attr, i) -%>

--- a/lib/generators/koi/admin_controller/templates/model_template.rb
+++ b/lib/generators/koi/admin_controller/templates/model_template.rb
@@ -1,8 +1,40 @@
 class <%= class_name %> < ActiveRecord::Base
+
 <%- if @orderable -%>
   has_crud :orderable => true<%= @versioned ? ", :versioned => true" : "" %>
 <%- else -%>
   has_crud<%= @versioned ? " :versioned => true" : "" %>
 <%- end -%>
-end
 
+<%- model_attributes.each do |attr| -%>
+    <%- if field_is_enum?(attr.name, attr.type) -%>
+  <%= "#{attr.name.pluralize.upcase} = { active: 'Active', inactive: 'Inactive' }\n" -%>
+  <%= "enum #{attr.name}: #{attr.name.pluralize.upcase}.keys\n" -%>
+  <%= "validates :#{attr.name}, presence: true\n\n" -%>
+    <%- end -%>
+    <%- if field_is_image?(attr.name, attr.type) -%>
+  <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :image\n" -%>
+  <%= "validates_property :format, of: :#{attr.name.chomp('_uid')}, in: ['jpeg', 'png', 'gif', 'png']\n\n" -%>
+    <%- end -%>
+    <%- if field_is_file?(attr.name, attr.type) -%>
+  <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :file\n" -%>
+  <%= "validates_property :ext, of: :#{attr.name.chomp('_uid')}, in: ['pdf', 'doc', 'docx', 'csv', 'txt']\n\n" -%>
+    <%- end -%>
+<%- end -%>
+
+  crud.config do
+    fields <%- model_attributes.each_with_index do |attr, i| -%>
+  <%= make_field_type(attr, i) -%>
+  <%- end -%>
+
+    config :admin do
+      exportable true
+      actions only:  [:index, :show, :new, :edit]
+      index fields: <%= crud_field_list %>,
+            order:  { created_at: :desc }
+      form  fields: <%= crud_field_list %>
+      csv   fields: <%= crud_csv_field_list %>
+    end
+  end
+
+end

--- a/lib/generators/koi/admin_controller/templates/model_template.rb
+++ b/lib/generators/koi/admin_controller/templates/model_template.rb
@@ -6,10 +6,11 @@ class <%= class_name %> < ActiveRecord::Base
   has_crud<%= @versioned ? " :versioned => true" : "" %>
 <%- end -%>
 
-<%- model_attributes.each do |attr| -%>
-  <%= make_field_config(attr) -%>
-<%- end -%>
-
+<%= render_enums %>
+<%= render_associations %>
+<%= render_images %>
+<%= render_files %>
+<%= render_urls %>
   crud.config do
     fields <%- model_attributes.each_with_index do |attr, i| -%>
   <%= make_field_type(attr, i) -%>

--- a/lib/generators/koi/admin_controller/templates/model_template.rb
+++ b/lib/generators/koi/admin_controller/templates/model_template.rb
@@ -7,19 +7,7 @@ class <%= class_name %> < ActiveRecord::Base
 <%- end -%>
 
 <%- model_attributes.each do |attr| -%>
-    <%- if field_is_enum?(attr.name, attr.type) -%>
-  <%= "#{attr.name.pluralize.upcase} = { active: 'Active', inactive: 'Inactive' }\n" -%>
-  <%= "enum #{attr.name}: #{attr.name.pluralize.upcase}.keys\n" -%>
-  <%= "validates :#{attr.name}, presence: true\n\n" -%>
-    <%- end -%>
-    <%- if field_is_image?(attr.name, attr.type) -%>
-  <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :image\n" -%>
-  <%= "validates_property :format, of: :#{attr.name.chomp('_uid')}, in: ['jpeg', 'png', 'gif', 'png']\n\n" -%>
-    <%- end -%>
-    <%- if field_is_file?(attr.name, attr.type) -%>
-  <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :file\n" -%>
-  <%= "validates_property :ext, of: :#{attr.name.chomp('_uid')}, in: ['pdf', 'doc', 'docx', 'csv', 'txt']\n\n" -%>
-    <%- end -%>
+  <%= make_field_config(attr) -%>
 <%- end -%>
 
   crud.config do

--- a/lib/generators/koi/controller/controller_generator.rb
+++ b/lib/generators/koi/controller/controller_generator.rb
@@ -178,6 +178,14 @@ module Koi
         ActiveRecord::Generators::Base.next_migration_number(dirname)
       end
 
+      #for permitted params like :retained_image and :remove_image
+      def file_and_image_params
+        (file_attributes+image_attributes).map do |attr|
+          name = attr.name.chomp('_uid')
+          [:"retained_#{name}", :"remove_#{name}"]
+        end.flatten
+      end
+
     end
   end
 end

--- a/lib/generators/koi/controller/controller_generator.rb
+++ b/lib/generators/koi/controller/controller_generator.rb
@@ -178,14 +178,6 @@ module Koi
         ActiveRecord::Generators::Base.next_migration_number(dirname)
       end
 
-      #for permitted params like :retained_image and :remove_image
-      def file_and_image_params
-        (file_attributes+image_attributes).map do |attr|
-          name = attr.name.chomp('_uid')
-          [:"retained_#{name}", :"remove_#{name}"]
-        end.flatten
-      end
-
     end
   end
 end

--- a/lib/generators/koi/controller/templates/controller_template.rb
+++ b/lib/generators/koi/controller/templates/controller_template.rb
@@ -1,7 +1,7 @@
 class <%= plural_class_name %>Controller < CrudController
 
   private
-    def permitted_params
-      params.permit(<%= "#{class_name.downcase}: #{crud_field_list + file_and_image_params}" %>)
-    end
+
+  <%= make_permitted_params %>
+  
 end

--- a/lib/generators/koi/controller/templates/controller_template.rb
+++ b/lib/generators/koi/controller/templates/controller_template.rb
@@ -1,3 +1,7 @@
 class <%= plural_class_name %>Controller < CrudController
-end
 
+  private
+    def permitted_params
+      params.permit(<%= "#{class_name.downcase}: #{crud_field_list + file_and_image_params}" %>)
+    end
+end

--- a/lib/generators/koi/controller/templates/migration_template.rb
+++ b/lib/generators/koi/controller/templates/migration_template.rb
@@ -2,7 +2,7 @@ class Create<%= class_name.pluralize.delete('::') %> < ActiveRecord::Migration
   def change
     create_table :<%= table_name %> do |t|
 <%- model_attributes.each do |attribute| -%>
-      t.<%= attribute.type %> :<%= attribute.name %>
+      t.<%= attribute.type %> :<%= attribute.name %><%= ", polymorphic: true" if attribute.polymorphic? %><%= ", index: true" if attribute.has_index? %>
 <%- end -%>
 <%- if @versioned -%>
       t.string :aasm_state
@@ -17,4 +17,3 @@ class Create<%= class_name.pluralize.delete('::') %> < ActiveRecord::Migration
     add_index :<%= table_name %>, :slug, :unique => true
   end
 end
-

--- a/lib/generators/koi/controller/templates/model_template.rb
+++ b/lib/generators/koi/controller/templates/model_template.rb
@@ -11,5 +11,6 @@ class <%= class_name %> < ActiveRecord::Base
 <%= render_images %>
 <%= render_files %>
 <%= render_urls %>
+<%= render_booleans %>
 
 end

--- a/lib/generators/koi/controller/templates/model_template.rb
+++ b/lib/generators/koi/controller/templates/model_template.rb
@@ -1,13 +1,15 @@
 class <%= class_name %> < ActiveRecord::Base
-  
+
 <%- if @orderable -%>
   has_crud :orderable => true<%= @versioned ? ", :versioned => true" : "" %>
 <%- else -%>
   has_crud<%= @versioned ? " :versioned => true" : "" %>
 <%- end -%>
 
-<%- model_attributes.each do |attr| -%>
-  <%= make_field_config(attr) -%>
-<%- end -%>
+<%= render_enums %>
+<%= render_associations %>
+<%= render_images %>
+<%= render_files %>
+<%= render_urls %>
 
 end

--- a/lib/generators/koi/controller/templates/model_template.rb
+++ b/lib/generators/koi/controller/templates/model_template.rb
@@ -1,8 +1,13 @@
 class <%= class_name %> < ActiveRecord::Base
+  
 <%- if @orderable -%>
   has_crud :orderable => true<%= @versioned ? ", :versioned => true" : "" %>
 <%- else -%>
   has_crud<%= @versioned ? " :versioned => true" : "" %>
 <%- end -%>
-end
 
+<%- model_attributes.each do |attr| -%>
+  <%= make_field_config(attr) -%>
+<%- end -%>
+
+end

--- a/lib/generators/koi/mailer/templates/controller_template.rb
+++ b/lib/generators/koi/mailer/templates/controller_template.rb
@@ -17,4 +17,8 @@ class <%= plural_class_name %>Controller < CrudController
     end
   end
 
+  private
+
+  <%= make_permitted_params %>
+
 end

--- a/lib/generators/koi/mailer/templates/migration_template.rb
+++ b/lib/generators/koi/mailer/templates/migration_template.rb
@@ -2,7 +2,7 @@ class Create<%= class_name.pluralize.delete('::') %> < ActiveRecord::Migration
   def change
     create_table :<%= table_name %> do |t|
 <%- model_attributes.each do |attribute| -%>
-      t.<%= attribute.type %> :<%= attribute.name %>
+      t.<%= attribute.type %> :<%= attribute.name %><%= ", polymorphic: true" if attribute.polymorphic? %><%= ", index: true" if attribute.has_index? %>
 <%- end -%>
 <%- if @versioned -%>
       t.string :aasm_state
@@ -17,4 +17,3 @@ class Create<%= class_name.pluralize.delete('::') %> < ActiveRecord::Migration
     add_index :<%= table_name %>, :slug, :unique => true
   end
 end
-

--- a/lib/generators/koi/mailer/templates/model_template.rb
+++ b/lib/generators/koi/mailer/templates/model_template.rb
@@ -2,10 +2,6 @@ class <%= class_name %> < ActiveRecord::Base
 
   has_crud settings: true
 
-  <%- model_attributes.each do |attr| -%>
-    <%= make_field_config(attr) -%>
-  <%- end -%>
-
   <%= render_enums %>
   <%= render_associations %>
   <%= render_images %>

--- a/lib/generators/koi/mailer/templates/model_template.rb
+++ b/lib/generators/koi/mailer/templates/model_template.rb
@@ -3,19 +3,7 @@ class <%= class_name %> < ActiveRecord::Base
   has_crud settings: true
 
   <%- model_attributes.each do |attr| -%>
-      <%- if field_is_enum?(attr.name, attr.type) -%>
-    <%= "#{attr.name.pluralize.upcase} = { active: 'Active', inactive: 'Inactive' }\n" -%>
-    <%= "enum #{attr.name}: #{attr.name.pluralize.upcase}.keys\n" -%>
-    <%= "validates :#{attr.name}, presence: true\n\n" -%>
-      <%- end -%>
-      <%- if field_is_image?(attr.name, attr.type) -%>
-    <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :image\n" -%>
-    <%= "validates_property :format, of: :#{attr.name.chomp('_uid')}, in: ['jpeg', 'png', 'gif', 'png']\n\n" -%>
-      <%- end -%>
-      <%- if field_is_file?(attr.name, attr.type) -%>
-    <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :file\n" -%>
-    <%= "validates_property :ext, of: :#{attr.name.chomp('_uid')}, in: ['pdf', 'doc', 'docx', 'csv', 'txt']\n\n" -%>
-      <%- end -%>
+    <%= make_field_config(attr) -%>
   <%- end -%>
 
   crud.config do

--- a/lib/generators/koi/mailer/templates/model_template.rb
+++ b/lib/generators/koi/mailer/templates/model_template.rb
@@ -6,6 +6,11 @@ class <%= class_name %> < ActiveRecord::Base
     <%= make_field_config(attr) -%>
   <%- end -%>
 
+  <%= render_enums %>
+  <%= render_associations %>
+  <%= render_images %>
+  <%= render_files %>
+  <%= render_urls %>
   crud.config do
     config :admin do
       exportable true

--- a/lib/generators/koi/mailer/templates/model_template.rb
+++ b/lib/generators/koi/mailer/templates/model_template.rb
@@ -2,10 +2,29 @@ class <%= class_name %> < ActiveRecord::Base
 
   has_crud settings: true
 
+  <%- model_attributes.each do |attr| -%>
+      <%- if field_is_enum?(attr.name, attr.type) -%>
+    <%= "#{attr.name.pluralize.upcase} = { active: 'Active', inactive: 'Inactive' }\n" -%>
+    <%= "enum #{attr.name}: #{attr.name.pluralize.upcase}.keys\n" -%>
+    <%= "validates :#{attr.name}, presence: true\n\n" -%>
+      <%- end -%>
+      <%- if field_is_image?(attr.name, attr.type) -%>
+    <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :image\n" -%>
+    <%= "validates_property :format, of: :#{attr.name.chomp('_uid')}, in: ['jpeg', 'png', 'gif', 'png']\n\n" -%>
+      <%- end -%>
+      <%- if field_is_file?(attr.name, attr.type) -%>
+    <%= "dragonfly_accessor :#{attr.name.chomp('_uid')}, app: :file\n" -%>
+    <%= "validates_property :ext, of: :#{attr.name.chomp('_uid')}, in: ['pdf', 'doc', 'docx', 'csv', 'txt']\n\n" -%>
+      <%- end -%>
+  <%- end -%>
+
   crud.config do
     config :admin do
+      exportable true
       actions only:  [:index, :show]
-      index   order: { created_at: :desc }
+      index fields: <%= crud_field_list %>,
+            order:  { created_at: :desc }
+      csv  fields: <%= crud_csv_field_list %>
     end
   end
 

--- a/lib/generators/koi/mailer/templates/model_template.rb
+++ b/lib/generators/koi/mailer/templates/model_template.rb
@@ -11,6 +11,7 @@ class <%= class_name %> < ActiveRecord::Base
   <%= render_images %>
   <%= render_files %>
   <%= render_urls %>
+  <%= render_booleans %>
   crud.config do
     config :admin do
       exportable true

--- a/lib/generators/koi/mailer/templates/views/thanks.html.erb
+++ b/lib/generators/koi/mailer/templates/views/thanks.html.erb
@@ -1,3 +1,4 @@
 <%% content_for :title, "<%= singular_name.titleize %>" %>
 
-<p>Thanks for your submission.</p>
+<% setting = "#{class_name}.setting(:thanks_message, '<p>Thanks for your submission.</p>', field_type: 'rich_text', role: 'Admin')" %>
+<%%= raw <%= setting %> %>


### PR DESCRIPTION
Additions to the  koi controller generators to automatically generate configuration/validation for various common field types we use, including enums for type/status pulldowns, dragonfly images/files, associations, and url fields, dates and booleans.

See RFC: #236 
