### PR TITLE
Completed the 'navigation: true' crud option functionality

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -22,4 +22,14 @@ class Page < ActiveRecord::Base
       form    except: [:type]
     end
   end
+
+  # overriding has_navigation methods to work with koi page route namespacing
+  def self.get_new_admin_url(options={})
+    Koi::Engine.routes.url_helpers.new_page_path(options)
+  end
+
+  def get_edit_admin_url(page, options={})
+    Koi::Engine.routes.url_helpers.edit_page_path(page, options)
+  end
+
 end

--- a/app/views/koi/nav_items/_nav_item.html.erb
+++ b/app/views/koi/nav_items/_nav_item.html.erb
@@ -49,7 +49,9 @@
                   <%= content_tag :li, link_to("Module", new_module_nav_item_path(site_parent: nav_item.id), remote: true, class: "button") if current_admin.god? %>
                   <%= content_tag :li, link_to("Alias" , new_alias_nav_item_path(site_parent: nav_item.id), remote: true, class: "button") %>
                   <%= content_tag :li, link_to("Folder", new_folder_nav_item_path(site_parent: nav_item.id), remote: true, class: "button") %>
-                  <%= content_tag :li, link_to("Page"  , new_page_path(site_parent: nav_item.id), class: "button") %>
+                  <% has_navigation_models.each do |model| %>
+                    <%= content_tag :li, link_to(model.to_s, model.get_new_admin_url(site_parent: nav_item.id), class: "button")  %>
+                  <% end %>
                 </ul>
               </li>
               <li>

--- a/lib/has_crud/has_crud/action_controller.rb
+++ b/lib/has_crud/has_crud/action_controller.rb
@@ -6,7 +6,7 @@ module HasCrud
     def self.included(base)
       base.send :extend, ClassMethods
       base.send :include, InstanceMethods
-      base.send :helper_method, :has_crud?, :has_crud_models
+      base.send :helper_method, :has_crud?, :has_navigation_models, :has_crud_models
     end
 
     module ClassMethods
@@ -23,6 +23,11 @@ module HasCrud
         false
       end
 
+      def has_navigation_models
+        # get all models with has_crud navigation: true
+        has_crud_models.select{ |model| model.options[:navigation] }
+      end
+
       def has_crud_models
         # Make sure all the models are loaded.
         Dir["#{Rails.root}/app/models/**/*.rb"].each { |path| require_dependency path }
@@ -34,4 +39,3 @@ module HasCrud
     end
   end
 end
-

--- a/lib/has_crud/has_crud/action_controller.rb
+++ b/lib/has_crud/has_crud/action_controller.rb
@@ -25,7 +25,7 @@ module HasCrud
 
       def has_navigation_models
         # get all models with has_crud navigation: true
-        has_crud_models.select{ |model| model.options[:navigation] }
+        @has_navigation_models || has_crud_models.select{ |model| model.options[:navigation] }
       end
 
       def has_crud_models

--- a/lib/has_crud/has_crud/action_controller.rb
+++ b/lib/has_crud/has_crud/action_controller.rb
@@ -25,7 +25,7 @@ module HasCrud
 
       def has_navigation_models
         # get all models with has_crud navigation: true
-        @has_navigation_models || has_crud_models.select{ |model| model.options[:navigation] }
+        @has_navigation_models ||= has_crud_models.select{ |model| model.options[:navigation] }
       end
 
       def has_crud_models

--- a/lib/has_crud/has_crud/action_controller/crud_admin_additions.rb
+++ b/lib/has_crud/has_crud/action_controller/crud_admin_additions.rb
@@ -49,7 +49,7 @@ module HasCrud
             if params[:commit].eql?("Continue")
               edit_resource_path
             elsif @site_parent || (resource.respond_to?(:resource_nav_item) && resource.resource_nav_item)
-              sitemap_nav_items_path
+              koi_engine.sitemap_nav_items_path
             else
               collection_path
             end

--- a/lib/has_navigation/has_navigation/has_navigation.rb
+++ b/lib/has_navigation/has_navigation/has_navigation.rb
@@ -1,4 +1,27 @@
 module HasNavigation
+
+  #
+  # TO USE:
+  #
+  # In your model:
+  #
+  #   has_crud navigation: true
+  #
+  # It should now show up in the dropdown list when trying to add items in
+  # the sitemap.
+  #
+  # This assumes you have an admin resources route for the model in your routes
+  # and that it's not a nested resource. If it's nested, or there's something
+  # else out-of-the-ordinary with this resource, you may have to override the
+  # below methods `self.get_new_admin_url` and `get_edit_admin_url` in the model to return
+  # the correct paths for edit/new, perhaps based on some default parent resource.
+  # (Another option would be to have the parent resource selectable in the
+  # child resource form rather than it being a nested resource.)
+  #
+  # Similarly, it assumes that your front end route is not nested. You may need to
+  # override the `get_url` method to return the correct route based on the parent if so.
+  #
+
   def has_navigation(options={})
     # Include url helpers to generate default path.
     send :include, Rails.application.routes.url_helpers
@@ -11,14 +34,21 @@ module HasNavigation
   module Model
     extend ActiveSupport::Concern
 
-    module ClassMethods
+    class_methods do
+      def get_new_admin_url(options={})
+        begin
+          new_polymorphic_path [:admin, self], options
+        rescue
+          Rails.application.routes.url_helpers.send :"new_admin_#{ self.name.singularize.parameterize '_' }_path", options
+        end
+      end
     end
 
-    def get_admin_url
+    def get_edit_admin_url(options={})
       begin
       edit_polymorphic_path [:admin, self]
       rescue
-        Koi::Engine.routes.url_helpers.send :"edit_#{ self.class.name.singularize.parameterize '_' }_path", self
+        Koi::Engine.routes.url_helpers.send :"edit_admin_#{ self.class.name.singularize.parameterize '_' }_path", self, options
       end
     end
 
@@ -46,7 +76,7 @@ module HasNavigation
       resource_nav_item = get_nav_item
 
       options.reverse_merge!(title: new_title, url: get_url,
-                             admin_url: get_admin_url,
+                             admin_url: get_edit_admin_url,
                              setting_prefix: get_setting_prefix,
                              navigable: self)
 

--- a/lib/has_navigation/has_navigation/has_navigation.rb
+++ b/lib/has_navigation/has_navigation/has_navigation.rb
@@ -21,6 +21,8 @@ module HasNavigation
   # Similarly, it assumes that your front end route is not nested. You may need to
   # override the `get_url` method to return the correct route based on the parent if so.
   #
+  # Be sure to implemement `to_s` in your model so that it correctly generates nav item titles
+  #
 
   def has_navigation(options={})
     # Include url helpers to generate default path.
@@ -39,7 +41,7 @@ module HasNavigation
         begin
           new_polymorphic_path [:admin, self], options
         rescue
-          Rails.application.routes.url_helpers.send :"new_admin_#{ self.name.singularize.parameterize '_' }_path", options
+          Rails.application.routes.url_helpers.send :"new_admin_#{ self.name.singularize.underscore }_path", options
         end
       end
     end
@@ -48,7 +50,7 @@ module HasNavigation
       begin
       edit_polymorphic_path [:admin, self]
       rescue
-        Koi::Engine.routes.url_helpers.send :"edit_admin_#{ self.class.name.singularize.parameterize '_' }_path", self, options
+        Koi::Engine.routes.url_helpers.send :"edit_admin_#{ self.class.name.singularize.underscore }_path", self, options
       end
     end
 
@@ -57,7 +59,13 @@ module HasNavigation
     end
 
     def get_title
-      respond_to?(:title) ? title : "#{self.class} - #{self.id}"
+      if respond_to? :title
+        title
+      elsif respond_to? :name
+        name
+      else
+        to_s
+      end
     end
 
     def get_setting_prefix

--- a/test/dummy/app/models/category.rb
+++ b/test/dummy/app/models/category.rb
@@ -1,6 +1,6 @@
 class Category < ActiveRecord::Base
 
-  has_crud orderable: true, settings: true
+  has_crud orderable: true, settings: true, navigation: true
   has_many :products, -> { order("ordinal ASC") }
 
   accepts_nested_attributes_for :products, allow_destroy: true

--- a/test/dummy/app/models/news_item.rb
+++ b/test/dummy/app/models/news_item.rb
@@ -1,6 +1,6 @@
 class NewsItem < ActiveRecord::Base
 
-  has_crud
+  has_crud navigation: true
 
   crud.config do
     config :admin do
@@ -22,4 +22,3 @@ class NewsItem < ActiveRecord::Base
   end
 
 end
-


### PR DESCRIPTION
Specifying `has_crud navigation: true` in a model now allows for these items to be created directly from the sitemap.
