### PR TITLE
fixed SEO setting defaults in generated koi.rb

### DIFF
--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -334,15 +334,15 @@ Koi::Menu.items = {
 }
 
 Koi::Settings.collection = {
-  title:            { label: "Title",            group: "SEO", field_type: 'string' },
-  meta_description: { label: "Meta Description", group: "SEO", field_type: 'text' },
-  meta_keywords:    { label: "Meta Keywords",    group: "SEO", field_type: 'text' }
+  title:            { label: "Title",            group: "SEO", field_type: 'string', role: 'Admin' },
+  meta_description: { label: "Meta Description", group: "SEO", field_type: 'text', role: 'Admin' },
+  meta_keywords:    { label: "Meta Keywords",    group: "SEO", field_type: 'text', role: 'Admin' }
 }
 
 Koi::Settings.resource = {
-  title:            { label: "Title",            group: "SEO", field_type: 'string' },
-  meta_description: { label: "Meta Description", group: "SEO", field_type: 'text' },
-  meta_keywords:    { label: "Meta Keywords",    group: "SEO", field_type: 'text' }
+  title:            { label: "Title",            group: "SEO", field_type: 'string', role: 'Admin' },
+  meta_description: { label: "Meta Description", group: "SEO", field_type: 'text', role: 'Admin' },
+  meta_keywords:    { label: "Meta Keywords",    group: "SEO", field_type: 'text', role: 'Admin' }
 }
 END
 


### PR DESCRIPTION
This was causing an issue where any model with settings: true was creating SEO settings with the default role being God, so regular admins (clients using Koi) could not manage SEO settings
