### PR TITLE
fixed sort method so it works for nested resources

### DIFF
--- a/lib/has_crud/has_crud/action_controller/admin/crud_methods.rb
+++ b/lib/has_crud/has_crud/action_controller/admin/crud_methods.rb
@@ -59,9 +59,9 @@ module HasCrud
           end
 
           def sort
-            order = params[singular_name(:symbol)]
-            resource_class.orderable(order)
-            render :text => nil
+            ordered_ids = params[singular_name(:symbol)]
+            collection.orderable(ordered_ids)
+            render text: nil
           end
 
           # FIXME: Imporve the sorting based on methods


### PR DESCRIPTION
Previously it was trying to sorted all instances of a model, even if it was a nested route. For example, with categories and products, ordering sink products in the sink category was screwing with the ordering of taps in the tap category.