### PR TITLE
CKEditor Fixes (#259)

### DIFF
--- a/app/assets/javascripts/koi/application.js
+++ b/app/assets/javascripts/koi/application.js
@@ -111,20 +111,6 @@
     // Change hash for page-reload
     // $('.nav-tabs a').on('shown', function (e) {
     $(document).on("ornament:tab-change", function(){
-      console.log("tab has changed");
-
-      for(k in CKEDITOR.instances) {
-          var instance = CKEDITOR.instances[k];
-          if(instance) {
-            instance.destroy(true)
-          }
-      }
-
-      $ ('.wysiwyg.source').each(function() {
-        // FIXME: Duplicated in wysiwyg.js
-        // CKEDITOR.replace (this);
-      });
-
       var scrollmem = $('body').scrollTop();
       window.location.hash = e.target.hash;
       $('html,body').scrollTop(scrollmem);

--- a/app/assets/javascripts/koi/koi/wysiwyg.js
+++ b/app/assets/javascripts/koi/koi/wysiwyg.js
@@ -6,12 +6,9 @@
 
     function wysiwyg() {
       var instance = CKEDITOR.instances[this.id];
-      if (instance) {
-        instance.removeAllListeners();
-        delete instance.editor;
-        instance.destroy(true);
+      if (!instance) {
+        CKEDITOR.replace(this);
       }
-      CKEDITOR.replace(this);
     }
 
     $.fn.wysiwyg = function() {
@@ -21,46 +18,6 @@
     $('.wysiwyg.source').wysiwyg();
 
     //////////////////////////////////////////////////////////// Configuration //
-
-    // Dynamic Toolbar //////////////////////////////////////////////////////////
-
-    CKEDITOR.on ('instanceReady', function (ck)
-    {
-      var  dockHeight            = 44 // height of Koi menu bar, which is fixed
-      var $window                = $ (window)
-      var  container             = ck.editor.container.$
-      var $container             = $ (container)
-      var $containerWindow       = $container.find ('iframe').$contentWindow ()
-      var $toolbar               = $container.find ('.cke_top')
-      var $bar                   = $ ('<div>').css ({ width:$container.innerWidth (), height:$toolbar.outerHeight () })
-      var  toolbarAbsolute       = { position:'absolute', top:0, left:0, width:$toolbar.css ('width') }
-      var  toolbarFixed          = { position:'fixed', top:dockHeight, left:$toolbar.offset ().left }
-
-      $container.css ({ position:'relative' })
-      $toolbar.css (toolbarAbsolute)
-
-      $bar.insertBefore ($toolbar)
-
-      $window.on ('scroll', balance)
-      $containerWindow.ready (balance).load (balance)
-
-      function balance ()
-      {
-        var containerOffset = $container.offset ()
-        var containerTop    = containerOffset.top
-        var containerBottom = containerOffset.top + $container.outerHeight ()
-        var scrollTop       = $window.scrollTop ()
-
-        var balanceTop      = scrollTop + dockHeight     - containerTop
-        var balanceBottom   = scrollTop + dockHeight * 2 - containerBottom
-
-        var balanceInside = balanceTop > 0 && balanceBottom < 0
-
-        $toolbar.css (balanceInside ? toolbarFixed : toolbarAbsolute)
-      }
-    })
-
-    ////////////////////////////////////////////////////////// Dynamic Toolbar //
 
     // Tidy Source //////////////////////////////////////////////////////////////
 
@@ -154,21 +111,6 @@
 
   $(document).on("ornament:refresh", function(){
     $(document).trigger("ornament:ck-editor");
-  });
-
-  $(document).on("ornament:tab-change", function(){
-
-    for(k in CKEDITOR.instances) {
-      var instance = CKEDITOR.instances[k];
-      if(instance) {
-        instance.destroy(true)
-      }
-    }
-
-    $ ('.wysiwyg.source').each(function() {
-      CKEDITOR.replace (this);
-    });
-
   });
 
 }(document, window, jQuery));

--- a/app/views/koi/admin_crud/_form_field_inline.html.erb
+++ b/app/views/koi/admin_crud/_form_field_inline.html.erb
@@ -70,7 +70,6 @@
         $(this).parent("h3").toggleClass("nested-fields-visible");
         $(this).parent("h3").parent(".nested-fields").siblings().find("h3").removeClass("nested-fields-visible").next(".nested-inline-fields").hide();
         $(this).closest(".nested-fields").children(".nested-inline-fields").toggle();
-        reInitCkEditor();
       });
 
       $('body').bind('cocoon:after-insert', function(event, insertedItem) {
@@ -108,7 +107,6 @@
             handle: ".drag-me",
             stop: function( event, ui ) {
               updateOrdinal(nested_inline_fields);
-              reInitCkEditor();
             }
           });
 
@@ -122,8 +120,15 @@
       });
 
       $('body').bind('cocoon:after-insert', function(event, insertedItem) {
-        var nested_inline_fields = insertedItem.parent().children(".nested-fields").children(".nested-inline-fields");
+        var allNestedGroups = insertedItem.parent().children(".nested-fields");
+        var siblings = allNestedGroups.not(insertedItem);
+        var nested_inline_fields = allNestedGroups.children(".nested-inline-fields");
+        siblings.each(function(){
+          siblings.find(".nested-fields-visible").removeClass("nested-fields-visible");
+          siblings.find(".nested-inline-fields").hide();
+        });
         updateOrdinal(nested_inline_fields);
+        $(document).trigger("ornament:ck-editor");
       });
 
     <%- end -%>


### PR DESCRIPTION
* Removed sticky CKEditor toolbar as per #259
* Removed reinitialisation of CKEditor when opening/closing inline nested groups. 
* Removed reinitialisation of CKEDitor when changing tabs
* Updated the `wysiwyg()` function to only initialise on CKEditors that aren't already initialised, rather than nuking them all then initialising them all again. 
* Fixed adding a new inline nested group not initialising newly added CKEditors immediately 
* Improved UX of adding inline nested groups by collapsing other inline nested items. This reflects the behaviour of toggling them open/closed which only allows one open at a time. Not related to CKEditor but an easy fix while I was there. 