### PR TITLE
Feature/257 hook up seo tabs

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -28,8 +28,8 @@ class Page < ActiveRecord::Base
     Koi::Engine.routes.url_helpers.new_page_path(options)
   end
 
-  def get_edit_admin_url(page, options={})
-    Koi::Engine.routes.url_helpers.edit_page_path(page, options)
+  def get_edit_admin_url(options={})
+    Koi::Engine.routes.url_helpers.edit_page_path(self, options)
   end
 
 end

--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -1,3 +1,18 @@
+#
+# When working with this file, it might help to enable binding.pry
+#
+# require 'pry'
+# binding.pry
+
+#
+# override Thor's source_paths method to include the rails_root directory in lib/templates/application/rails_root
+# For consistency, any files we want to copy into the app should be placed inside rails_root,
+# following the rails folder structure.
+#
+def source_paths
+  Array(super) + [File.join(File.expand_path(File.dirname(__FILE__)),'rails_root')]
+end
+
 # Add .ruby-version for RVM/RBENV.
 create_file '.ruby-version', <<-END
 2.2.2
@@ -121,6 +136,7 @@ module CommonControllerActions
     layout :layout_by_resource
     helper :all
     helper Koi::NavigationHelper
+    helper_method :seo
     before_filter :sign_in_as_admin! if Rails.env.development?
   end
 
@@ -186,6 +202,9 @@ class CrudController < Koi::CrudController
 
 end
 END
+
+# import Pages controller
+copy_file 'app/controllers/pages_controller.rb'
 
 run 'bundle install'
 

--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -149,6 +149,22 @@ module CommonControllerActions
     sign_in(:admin, Admin.first) unless Admin.all.empty?
   end
 
+  def seo(name)
+    begin
+      is_a_resource? ? resource.setting(name, nil, role: 'Admin') : resource_class.setting(name, nil, role: 'Admin')
+    rescue
+    end
+  end
+
+  # Is the current page an Inherited Resources resource?
+  def is_a_resource?
+    begin
+      !!resource
+    rescue
+      false
+    end
+  end
+
 end
 END
 

--- a/lib/templates/application/rails_root/app/controllers/pages_controller.rb
+++ b/lib/templates/application/rails_root/app/controllers/pages_controller.rb
@@ -1,0 +1,15 @@
+class PagesController < CrudController
+
+  # Stop accidental leakage of unwanted actions to frontend
+
+  def index
+    redirect_to '/'
+  end
+
+  alias :index :create
+  alias :index :destroy
+  alias :index :update
+  alias :index :edit
+  alias :index :new
+
+end


### PR DESCRIPTION
Added the necessary SEO method to pull settings from records if it's a crud controller, to work with Ornament's seo partial. . 

Along the way, I've also set the groundwork for refactoring the app.rb template. A whole bunch of the files that koi generates for the project are created with `create_file` and `<<-HEREDOC` strings.

![image](https://cloud.githubusercontent.com/assets/7999019/23053821/e11e156e-f52b-11e6-8dae-4b5336894fd5.png)

These can now be pulled into their own files in the `lib/templates/application/rails_root` in a rails-like structure, using `copy_file` instead. e.g.

```ruby
# lib/templates/application/rails_root/app/controllers/pages_controller.rb
class PagesController < CrudController
   # ...
end

# lib/templates/application/app.rb
copy_file 'app/controllers/pages_controller.rb'
```

This is similar to how the Ornament generator works, and will be much more testable and maintainable. 