### PR TITLE
Issue 225 - Fixed flash message colour on success

### DIFF
--- a/app/assets/stylesheets/koi/components/_island.scss
+++ b/app/assets/stylesheets/koi/components/_island.scss
@@ -46,8 +46,7 @@ $island-error-background:   mix($error-color, $white, 10);
 }
 
 // Colour variations
-.island__warning,
-.island__notice {
+.island__warning {
   @extend .island;
   background: $island-warning-background;
 
@@ -66,7 +65,8 @@ $island-error-background:   mix($error-color, $white, 10);
   }
 }
 
-.island__success {
+.island__success,
+.island__notice {
   @extend .island;
   background: $island-success-background;
 


### PR DESCRIPTION
Inherited resources uses notice (success) and alert(error) by default. You can override these in config but only for respond_to. Respond_with with use only the defaults.
