### PR TITLE
Custom datepicker settings in crud config

### DIFF
--- a/app/assets/javascripts/koi/components/enhanced-form.js
+++ b/app/assets/javascripts/koi/components/enhanced-form.js
@@ -45,22 +45,112 @@
       defaultSettings = defaultSettings || {};
       // List of settings we can check against
       var settingsToCheck = [
-        "dateFormat", 
-        "yearRange",
-        "timeFormat",
-        "showButtonPanel", 
+        // jQueryUI Datepicker Options
+        // http://api.jqueryui.com/datepicker/
+        "appendText",
+        "autoSize",
         "changeMonth",
         "changeYear",
-        "stepMinute",
+        "closeText",
+        "contrainInput",
+        "currentText",
+        "dateFormat", 
+        "dayNames",
+        "dayNamesMin",
+        "dayNamesShort",
+        "defaultDate",
+        "duration",
+        "firstDay",
+        "gotoCurrent",
+        "hideIfNoPrevNext",
+        "maxDate",
+        "minDate",
+        "monthNames",
+        "monthNamesShort",
+        "navigationAsDateFormat",
+        "nextText",
+        "prevText",
+        "selectOtherMonths",
+        "shortYearCutoff",
+        "showAnim",
+        "showButtonPanel", 
+        "showCurrentAtPos",
+        "showMonthAfterYear",
+        "showOptions",
+        "showOtherMonths",
+        "showWeek",
+        "stepMonths",
+        "weekHeader",
+        "yearRange",
+        "yearSuffix",
+        // jQueryUI Datetimepicker Options
+        // http://trentrichardson.com/examples/timepicker/
+        "amNames",
+        "pmNames",
+        "timeFormat",
+        "timeSuffix",
+        "timeOnlyTitle",
+        "timeText",
+        "hourText",
+        "minuteText",
+        "secondText",
+        "millisecText",
+        "microsecText",
+        "timezoneText",
         "controlType",
-        "showButtonPanel",
+        "showHour",
+        "showMinute",
+        "showSecond",
+        "showMillisec",
+        "showMicroset",
+        "showTimezone",
+        "showTime",
+        "stepHour",
+        "stepMinute",
+        "stepSecond",
+        "stepMillisec",
+        "stepMicrosec",
+        "hour",
+        "minute",
+        "second",
+        "millisec",
+        "microsec",
+        "timezone",
+        "hourMin",
+        "minuteMin",
+        "secondMin",
+        "millisecMin",
+        "microsecMin",
+        "hourGrid",
+        "minuteGrid",
+        "secondGrid",
+        "millisecGrid",
+        "microsecGrid",
+        "timeInput",
+        "timeOnly",
+        "timeOnlyShowDate",
+        "seperator",
+        "pickerTimeFormat",
+        "pickerTimeSuffix",
+        "showTimepicker",
+        "defaultValue",
+        "minTime",
+        "maxTime"
       ];
       // Loop over the array of options above and over-write 
       // the default settings with the new ones
       $.each(settingsToCheck, function(){
         var attribute = "data-datepicker-" + this.toLowerCase();
-        if($field.is("[data-datepicker-" + attribute + "]")) {
-          defaultSettings[this] = $field.attr(attribute);
+        if($field.is("[" + attribute + "]")) {
+          var value = $field.attr(attribute);
+          if(value === "true") {
+            value = true;
+          } else if (value === "false") {
+            value = false;
+          } else if (!isNaN(parseInt(value))) {
+            value = parseInt(value);
+          }
+          defaultSettings[this] = value;
         }
       });
       return defaultSettings;
@@ -92,7 +182,7 @@
         $("input.datepicker, .datepicker input").not(".datepicker__enabled").each(function(){
           var $datepicker = $(this);
           var settings = FormHelpers._buildDatepickerSettingsForField($datepicker, datePickerSettings);
-          $datepicker.datepicker().addClass("datepicker__enabled");
+          $datepicker.datepicker(settings).addClass("datepicker__enabled");
         });
 
         // Datetime Picker

--- a/app/views/koi/admin_crud/_form_field.html.erb
+++ b/app/views/koi/admin_crud/_form_field.html.erb
@@ -7,11 +7,22 @@
   }
 
   input_opts = {
-    class: ""
+    class: "",
+    data: {}
   }
 
-  if crud_settings && crud_settings[:wrapper_data]
-    wrapper_opts[:data] = crud_settings[:wrapper_data]
+  if crud_settings 
+    if crud_settings[:wrapper_data]
+      wrapper_opts[:data] = crud_settings[:wrapper_data]
+    end
+    if crud_settings[:input_data]
+      input_opts[:data] = crud_settings[:input_data]
+    end
+    if crud_settings[:datepicker]
+      crud_settings[:datepicker].each do |opt,val| 
+        input_opts[:data]["datepicker_#{opt}"] = val
+      end
+    end
   end
 
   if crud_settings && crud_settings[:size]

--- a/test/dummy/app/models/super_hero.rb
+++ b/test/dummy/app/models/super_hero.rb
@@ -39,8 +39,8 @@ class SuperHero < ActiveRecord::Base
            last_location_seen:   { type: :latlng },
            powers:               { type: :check_boxes, data: Powers },
            images:               { type: :inline },
-           published_at:         { type: :date, size: :small },
-           telephone:        { type: :readonly }
+           published_at:         { type: :date, size: :small, datepicker: { dateformat: "dd M yy", maxdate: "0" } },
+           telephone:            { type: :readonly }
 
     index  fields: [:name, :description, :published_at, :gender, :is_alive, :url,
                     :telephone]


### PR DESCRIPTION
You can now customise your `:date` or `:datetime` fields with (almost) any option available in either API.

```ruby
published_at: { type: :date, datepicker: { dateformat: "dd M yy", maxdate: "0" } }
```

Options available are listed in the `enhanced-form.js` file and should cover off any basic settings. Anything more advanced such as custom callbacks and whatnot would probably warrant a custom field type. 