### PR TITLE
Added filter to slide-out menu

### DIFF
--- a/app/assets/javascripts/koi/components/navigation-mobile.js
+++ b/app/assets/javascripts/koi/components/navigation-mobile.js
@@ -422,10 +422,9 @@
             if($anchor) {
               var itemText = $anchor.text().trim().toLowerCase();
               // grab the url and strip out slashes, underscores, and 'admin'
-              var itemUrl = $anchor.attr("href").split("/");
-              var itemUrlCandidate = itemUrl.replace('admin', '').replace(/\//g, ' ').replace(/_/g, ' ')
+              var itemUrl = $anchor.attr("href").replace('admin', '').replace(/\//g, ' ').replace(/_/g, ' ');
               var isFound = Ornament.fuzzySearch(search, itemText) || 
-                            mobileNav.filterUrls && Ornament.fuzzySearch(search, itemUrlCandidate);
+                            mobileNav.filterUrls && Ornament.fuzzySearch(search, itemUrl);
               if(isFound) {
                 // build up a breadcrumb style of parent links
                 var $ancestors = $item.parents("li");

--- a/app/assets/javascripts/koi/components/navigation-mobile.js
+++ b/app/assets/javascripts/koi/components/navigation-mobile.js
@@ -38,6 +38,7 @@
       showOverviewLinks:          false, // will show overview links on secodary panes
       keepScrollPosition:         true, // keep scroll position when opening tabs, dangerous if button isn't fixed
       closeForAnchors:            false, // close menu when clicking on anchors
+      filterUrls:                 false, // filter returns results for last URL component as well as title
 
       // Customisable text strings
       viewOverviewText:           "View Overview",
@@ -420,7 +421,11 @@
             var $anchor = $item.children("a");
             if($anchor) {
               var itemText = $anchor.text().trim().toLowerCase();
-              if(Ornament.fuzzySearch(search, itemText)) {
+              var itemUrl = $anchor.attr("href").split("/");
+              var itemUrlCandidate = itemUrl[itemUrl.length - 1];
+              var isFound = Ornament.fuzzySearch(search, itemText) || 
+                            mobileNav.filterUrls && Ornament.fuzzySearch(search, itemUrlCandidate);
+              if(isFound) {
                 // build up a breadcrumb style of parent links
                 var $ancestors = $item.parents("li");
                 var $result = $item.clone();
@@ -475,6 +480,9 @@
         if(mobileNav.filterElement.length) {
           mobileNav.filterZone = $("<ul class='navigation-mobile--filter-zone' />");
           mobileNav.mainPane.after(mobileNav.filterZone);
+          if(mobileNav.filterElement.is("[data-tray-filter-urls]")) {
+            mobileNav.filterUrls = true;
+          }
         } else {
           mobileNav.filterZone = false;
         }

--- a/app/assets/javascripts/koi/components/navigation-mobile.js
+++ b/app/assets/javascripts/koi/components/navigation-mobile.js
@@ -440,6 +440,9 @@
               }
             }
           });
+          if(!mobileNav.filterZone.children().length) {
+            mobileNav.filterZone.append("<li class='navigation-mobile--filter--no-results'>There are no results for your filter search</li>");
+          }
           mobileNav.destroyTabIndexes();
           mobileNav.createTabIndexesForCurrentPane();
           mobileNav.updateMenuHeight();

--- a/app/assets/javascripts/koi/components/navigation-mobile.js
+++ b/app/assets/javascripts/koi/components/navigation-mobile.js
@@ -90,11 +90,11 @@
         var tabIndex = 2;
         currentPane.attr("tabIndex", 1);
         var currentFilter = currentPane.find("[data-tray-filter]");
-        if(currentFilter) {
+        if(currentFilter.length) {
           tabIndex++;
           currentFilter.attr("tabIndex", tabIndex);
         }
-        if(mobileNav.filterZone.is(":visible")) {
+        if(mobileNav.filterZone && mobileNav.filterZone.is(":visible")) {
           mobileNav.filterZone.find("a").each(function(){
             tabIndex++;
             $(this).attr("tabIndex", tabIndex);
@@ -162,7 +162,7 @@
         // Focus on the first link
         setTimeout(function(){
           mobileNav.destroyTabIndexesAndCreateForCurrentPane();
-          if(mobileNav.filterElement) {
+          if(mobileNav.filterElement.length) {
             mobileNav.filterElement.focus();
           } else {
             mobileNav.getCurrentPane().focus();
@@ -398,6 +398,9 @@
       clearFilter: function(){
         mobileNav.mainPane.show();
         mobileNav.filterZone.hide();
+        mobileNav.destroyTabIndexes();
+        mobileNav.createTabIndexesForCurrentPane();
+        mobileNav.updateMenuHeight();
       },
 
       filterMenu: function(search) {
@@ -450,9 +453,13 @@
         $currentTab.parent("li").addClass(mobileNav.menuSelectedClass);
 
         // Create a zone for filter results
-        mobileNav.filterZone = $("<ul class='navigation-mobile--filter-zone' />");
         mobileNav.mainPane = $tray.find("."+mobileNav.nonPaneClass);
-        mobileNav.mainPane.after(mobileNav.filterZone);
+        if(mobileNav.filterElement.length) {
+          mobileNav.filterZone = $("<ul class='navigation-mobile--filter-zone' />");
+          mobileNav.mainPane.after(mobileNav.filterZone);
+        } else {
+          mobileNav.filterZone = false;
+        }
 
         // Wrap each list in a pane div to assist in animation and sizing
         $tray.find("ul").not(mobileNav.mainPane).not(mobileNav.filterZone).wrap("<div class='"+mobileNav.paneClass+"' />");

--- a/app/assets/javascripts/koi/components/navigation-mobile.js
+++ b/app/assets/javascripts/koi/components/navigation-mobile.js
@@ -421,7 +421,22 @@
             if($anchor) {
               var itemText = $anchor.text().trim().toLowerCase();
               if(Ornament.fuzzySearch(search, itemText)) {
-                mobileNav.filterZone.append($item.clone());
+                // build up a breadcrumb style of parent links
+                var $ancestors = $item.parents("li");
+                var $result = $item.clone();
+                if($ancestors.length) {
+                  var ancestorText = "";
+                  $ancestors.reverse().each(function(i){
+                    ancestorText += $(this).children("a").text().trim();
+                    if(i+1 !== $ancestors.length) {
+                      ancestorText += " › ";
+                    }
+                  });
+                  var $ancestorLabel = $("<small class='navigation-mobile--filter--ancestor' />");
+                  $ancestorLabel.text(ancestorText);
+                  $result.children("a").prepend($ancestorLabel);
+                }
+                mobileNav.filterZone.append($result.clone());
               }
             }
           });

--- a/app/assets/javascripts/koi/components/navigation-mobile.js
+++ b/app/assets/javascripts/koi/components/navigation-mobile.js
@@ -78,7 +78,7 @@
       },
 
       // Destroy the tab indexes of all the links in the mobile menu
-      // This is used to stop screen readers and tabbing 
+      // This is used to stop screen readers and tabbing
       destroyTabIndexes: function() {
         mobileNav.tray.find(".pane").removeAttr("tabIndex");
         mobileNav.tray.find("a").attr("tabIndex", "-1");
@@ -167,7 +167,7 @@
             mobileNav.filterElement.focus();
           } else {
             mobileNav.getCurrentPane().focus();
-          } 
+          }
         }, mobileNav.slideTransitionTime);
 
       },
@@ -421,8 +421,9 @@
             var $anchor = $item.children("a");
             if($anchor) {
               var itemText = $anchor.text().trim().toLowerCase();
+              // grab the url and strip out slashes, underscores, and 'admin'
               var itemUrl = $anchor.attr("href").split("/");
-              var itemUrlCandidate = itemUrl[itemUrl.length - 1];
+              var itemUrlCandidate = itemUrl.replace('admin', '').replace(/\//g, ' ').replace(/_/g, ' ')
               var isFound = Ornament.fuzzySearch(search, itemText) || 
                             mobileNav.filterUrls && Ornament.fuzzySearch(search, itemUrlCandidate);
               if(isFound) {

--- a/app/assets/javascripts/koi/components/shortcuts.js
+++ b/app/assets/javascripts/koi/components/shortcuts.js
@@ -10,6 +10,11 @@
     // Toggle the menu open/close
     keyboardJS.bind("alt + m", function(e) {
       mobileNav.toggleMenu();
+      if(mobileNav.filterElement) {
+        mobileNav.filterElement.blur();
+        mobileNav.filterElement.val("");
+        mobileNav.clearFilter();
+      }
     });
 
     // Close the menu or close a lightbox

--- a/app/assets/javascripts/koi/ornament/defaults.js
+++ b/app/assets/javascripts/koi/ornament/defaults.js
@@ -145,6 +145,29 @@ Ornament = window.Ornament = {
     }
   },
 
+  // Fuzzysearch
+  // https://github.com/bevacqua/fuzzysearch/blob/master/index.js
+  fuzzySearch: function(needle, haystack){
+    var hlen = haystack.length;
+    var nlen = needle.length;
+    if (nlen > hlen) {
+      return false;
+    }
+    if (nlen === hlen) {
+      return needle === haystack;
+    }
+    outer: for (var i = 0, j = 0; i < nlen; i++) {
+      var nch = needle.charCodeAt(i);
+      while (j < hlen) {
+        if (haystack.charCodeAt(j++) === nch) {
+          continue outer;
+        }
+      }
+      return false;
+    }
+    return true;
+  },
+
   // Create a JS list of icons
   icons: {}
 

--- a/app/assets/stylesheets/koi/components/_layout.scss
+++ b/app/assets/stylesheets/koi/components/_layout.scss
@@ -1,4 +1,4 @@
-$layout-animation-duration:     0.5s;
+$layout-animation-duration:     0.2s;
 $layout-background:             $background-color;
 $layout-breakpoint:             $breakpoint-small;
 $layout-container-width:        $container-width;

--- a/app/assets/stylesheets/koi/components/_navigation-mobile.scss
+++ b/app/assets/stylesheets/koi/components/_navigation-mobile.scss
@@ -44,6 +44,10 @@ $navigation-secondary-pane-link-color:  #fff;
   opacity: 0.6;
 }
 
+.navigation-mobile--filter-zone {
+  display: none;
+}
+
 .navigation-mobile--header {
   border-bottom: $mobile-pane-header-border;
   line-height: 44px;

--- a/app/assets/stylesheets/koi/components/_navigation-mobile.scss
+++ b/app/assets/stylesheets/koi/components/_navigation-mobile.scss
@@ -30,6 +30,13 @@ $navigation-secondary-pane-link-color:  #fff;
   border-bottom: 1px solid $primary-color;
 }
 
+.navigation-mobile--filter--ancestor {
+  opacity: 0.6;
+  margin-bottom: 4px;
+  line-height: 1.5;
+  display: block;
+}
+
 .navigation-mobile--header {
   border-bottom: $mobile-pane-header-border;
   line-height: 44px;

--- a/app/assets/stylesheets/koi/components/_navigation-mobile.scss
+++ b/app/assets/stylesheets/koi/components/_navigation-mobile.scss
@@ -25,6 +25,11 @@ $navigation-secondary-pane-link-color:  #fff;
   background: $navigation-tray-background;
 }
 
+.navigation-mobile--filter {
+  padding: $xxx-small-unit;
+  border-bottom: 1px solid $primary-color;
+}
+
 .navigation-mobile--header {
   border-bottom: $mobile-pane-header-border;
   line-height: 44px;

--- a/app/assets/stylesheets/koi/components/_navigation-mobile.scss
+++ b/app/assets/stylesheets/koi/components/_navigation-mobile.scss
@@ -37,6 +37,13 @@ $navigation-secondary-pane-link-color:  #fff;
   display: block;
 }
 
+.navigation-mobile--filter--no-results {
+  padding: $xxx-small-unit;
+  @include font($italic-font);
+  color: $white;
+  opacity: 0.6;
+}
+
 .navigation-mobile--header {
   border-bottom: $mobile-pane-header-border;
   line-height: 44px;

--- a/app/views/layouts/koi/global.html.erb
+++ b/app/views/layouts/koi/global.html.erb
@@ -56,9 +56,11 @@
                 <div class="navigation-mobile--header">
                   koi
                 </div>
-                <div class="navigation-mobile--filter">
-                  <input type="search" placeholder="Filter menu" data-tray-filter />
-                </div>
+                <%- if Koi::Menu.filterable -%>
+                  <div class="navigation-mobile--filter">
+                    <input type="search" placeholder="Filter menu" data-tray-filter />
+                  </div>
+                <%- end -%>
                 <%= render :partial => "layouts/koi/navigation" %>
               </div>
             </div>

--- a/app/views/layouts/koi/global.html.erb
+++ b/app/views/layouts/koi/global.html.erb
@@ -56,6 +56,9 @@
                 <div class="navigation-mobile--header">
                   koi
                 </div>
+                <div class="navigation-mobile--filter">
+                  <input type="search" placeholder="Filter menu" data-tray-filter />
+                </div>
                 <%= render :partial => "layouts/koi/navigation" %>
               </div>
             </div>

--- a/app/views/layouts/koi/global.html.erb
+++ b/app/views/layouts/koi/global.html.erb
@@ -58,7 +58,7 @@
                 </div>
                 <%- if Koi::Menu.filterable -%>
                   <div class="navigation-mobile--filter">
-                    <input type="search" placeholder="Filter menu" data-tray-filter />
+                    <input type="search" placeholder="Filter menu" data-tray-filter <%= "data-tray-filter-urls" if Koi::Menu.filter_urls -%> />
                   </div>
                 <%- end -%>
                 <%= render :partial => "layouts/koi/navigation" %>

--- a/lib/koi/menu.rb
+++ b/lib/koi/menu.rb
@@ -5,5 +5,8 @@ module Koi
 
     mattr_accessor :advanced
     @@items = {}
+
+    mattr_accessor :filterable
+    @@filterable = true
   end
 end

--- a/lib/koi/menu.rb
+++ b/lib/koi/menu.rb
@@ -8,5 +8,8 @@ module Koi
 
     mattr_accessor :filterable
     @@filterable = true
+
+    mattr_accessor :filter_urls
+    @@filter_urls = true
   end
 end


### PR DESCRIPTION
![menu-filter-ancestors2](https://cloud.githubusercontent.com/assets/685024/23349323/29c49d78-fd02-11e6-8955-aefb20abcee8.jpg)

Discussion: https://github.com/katalyst/koi/issues/274

### Quickly search what you're looking for

* Fuzzy search using (using [this technique](https://github.com/bevacqua/fuzzysearch/blob/master/index.js))
* Filter automatically focuses when opening the menu, ready to be filtered
* Results show a breadcrumb-style helper to indicate what folders the result is in  
* When filtering, tabindices are regenerated so you can quickly tab down to your results 

### Configurable

Just building a small site that wouldn't warrant a menu filter? No worries! 

```ruby
# config/initializers/koi.rb
Koi::Menu.filterable = false
```