### PR TITLE
Removed sorting on non-database columns in index view [#273]

### DIFF
--- a/app/helpers/koi/application_helper.rb
+++ b/app/helpers/koi/application_helper.rb
@@ -13,13 +13,17 @@ module Koi::ApplicationHelper
   end
 
   def sortable(column, title = column.titleize, link_opt = {})
-    link_params = params.merge sort: column, direction: "asc", page: nil
-    link_opt.merge! data: { get_script: true }
-    if column == sort_column.to_s
-      link_params.merge! direction: (sort_direction.to_s == "asc" ? "desc" : "asc")
-      link_opt.merge! class: "sort icon pad-r-15px #{ sort_direction }"
+    if resource_class.column_names.include?(column) 
+      link_params = params.merge sort: column, direction: "asc", page: nil
+      link_opt.merge! data: { get_script: true }
+      if column == sort_column.to_s
+        link_params.merge! direction: (sort_direction.to_s == "asc" ? "desc" : "asc")
+        link_opt.merge! class: "sort icon pad-r-15px #{ sort_direction }"
+      end
+      link_to title, link_params, link_opt
+    else
+      content_tag(:span, title)
     end
-    link_to title, link_params, link_opt
   end
 
   def is_settable?


### PR DESCRIPTION
Fixes https://github.com/katalyst/koi/issues/273 (using option a)

> Often we use non-database fields in our koi listing pages, e.g.

```ruby
index fields: [:full_name]
# ....
def full_name
  first_name + " " + last_name
end
```

> Ordering by this column in the UI doesn't work at the moment. We should either (a) disable ordering for non-database fields, or (b) implement ordering for these fields (which would be a lot more work, and would be a bad idea for tables that have a very large number of records, since you'd have to do the sorting in Ruby.)