### PR TITLE
Remember which sitemap nodes were toggled open/closed

### DIFF
--- a/app/assets/javascripts/koi.js
+++ b/app/assets/javascripts/koi.js
@@ -4,6 +4,7 @@
 //= require jquery-ui
 //= require jquery_ujs
 //= require koi/picturefill
+//= require koi/store
 //= require select2
 //= require cocoon
 //= require koi/velocity

--- a/app/assets/javascripts/koi/nav_items.js
+++ b/app/assets/javascripts/koi/nav_items.js
@@ -1,125 +1,207 @@
 $(document).on("ornament:refresh", function(){
-  
-  var $lockButton = $("[data-sitemap-lock]");
 
-  var toggleKoiSitemapDragDropState = function(){
-    if(localStorage.koiSitemapDragDropDisabled) {
-      koiSetSitemapDragDropState("enabled");
-    } else {
-      koiSetSitemapDragDropState("disabled");
-    }
-  }
+  var Sitemap = Ornament.C.Sitemap = {
 
-  var koiSetSitemapDragDropState = function(state){
-    if(state === "enabled") {
-      localStorage.removeItem("koiSitemapDragDropDisabled");
-      $lockButton.removeClass("button__depressed");
-      $lockButton.text("Lock Dragging");
-      $(document).trigger("ornament:koi:sitemap:unlocked");
-    } else if (state === "disabled") {
-      localStorage.setItem("koiSitemapDragDropDisabled", "true");
-      $lockButton.addClass("button__depressed");
-      $lockButton.text("Unlock Dragging");
-      $(document).trigger("ornament:koi:sitemap:locked");
-    }
-  }
+    // Configuration
+    disabledButtonClass: "button__depressed",
+    closedNodeClass: 'mjs-nestedSortable-collapsed',
+    expandedNodeClass: 'mjs-nestedSortable-expanded',
+    selectors: {
+      tree: ".sitemap.application",
+      lockButtonSelector: "[data-sitemap-lock]",
+    },
+    storageKeys: {
+      dragDisabledKey: "koiSitemapDragDropDisabled",
+      closedNodeIds: "koiSitemapClosedNodes"
+    },
+    lang: {
+      enabledButton: "Lock Dragging",
+      disabledButton: "Unlock Dragging"
+    },
 
-  // Some nice public functions
-  Ornament.koiDisableSitemapDragDrop = function(){
-    koiSetSitemapDragDropState("disabled");
-  }
-  Ornament.koiEnableSitemapDragDrop = function(){
-    koiSetSitemapDragDropState("enabled");
-  }
+    getLockedStateFromLocalStorage: function(){
+      return store.get(Sitemap.storageKeys.dragDisabledKey);
+    },
 
-  function $toNestedSet ()
-  {
-    var nodes = [];
-    var n = 1;
+    getClosedNodesFromLocalStorage: function(){
+      return store.get(Sitemap.storageKeys.closedNodeIds);
+    },
 
-    ! function ()
-    {
-      var $this = $ (this);
-      var node = { id: $this.data ('id'), parent_id: $this.componentOf ().data ('id') };
+    setClosedNodesInLocalStorage: function(arrayOfSelections) {
+      arrayOfSelections = arrayOfSelections || [];
+      store.set(Sitemap.storageKeys.closedNodeIds, arrayOfSelections);
+    },
 
-      node.lft = n ++;
-      $ (this).components ('.nav-item.application').each (arguments.callee);
-      node.rgt = n ++;
+    // Toggle the sitemap state
+    toggleSitemapDragState: function(){
+      if(Sitemap.getLockedStateFromLocalStorage()) {
+        Sitemap.setSitemapDragStateEnabled();
+      } else {
+        Sitemap.setSitemapDragStateDisabled();
+      }
+  },
 
-      nodes.push (node);
-    }.call (this);
+    // Disable dragging of sitemap
+    setSitemapDragStateDisabled: function(){
+      store.set(Sitemap.storageKeys.dragDisabledKey, "true");
+      Sitemap.$lockButton.addClass(Sitemap.disabledButtonClass);
+      Sitemap.$lockButton.text(Sitemap.lang.disabledButton);
+      Sitemap.$rootList.removeClass("enabled").nestedSortable("destroy");
+    },
 
-    return nodes;
-  }
+    // Enable dragging of sitemep
+    setSitemapDragStateEnabled: function() {
+      store.remove(Sitemap.storageKeys.dragDisabledKey);
+      Sitemap.$lockButton.removeClass(Sitemap.disabledButtonClass);
+      Sitemap.$lockButton.text(Sitemap.lang.enabledButton);
+      Sitemap._bindSortableTree();
+    },
 
-  $ (".sitemap.application").application (function ($sitemap)
-  {
-    var path      = $sitemap.data ('uri-save');
-    var $rootList = $sitemap.find ('.sitemap--root');
-    var $rootItem = $sitemap.component ('.nav-item');
+    // Set the sitemap state based on string
+    setSitemapDragState: function(state) {
+      if(state === "enabled") {
+        Sitemap.setSitemapDragStateEnabled();
+      } else if (state === "disabled") {
+        Sitemap.setSitemapDragStateDisabled();
+      }
+    },
 
-    function save (cb) {
-      $.post (path, { set: render () }, cb);
-    }
+    toggleNode: function($node){
+      var currentClosedNodes = Sitemap.getClosedNodesFromLocalStorage() || [];
+      $node = $node.is("[data-node-id]") ? $node : $node.closest("[data-node-id]");
+      var nodeId = $node.attr("data-node-id");
+      var $container = $node.closest('li');
+      var $label = $node.children("span");
+      $container.toggleClass(Sitemap.closedNodeClass).toggleClass(Sitemap.expandedNodeClass);
+      $label.toggleClass('ui-icon-plusthick').toggleClass('ui-icon-minusthick');
+      if($container.hasClass(Sitemap.closedNodeClass)) {
+        console.log(nodeId + " is closed");
+        if(currentClosedNodes.indexOf(nodeId) === -1) {
+          console.log(nodeId + " adding to LS");
+          currentClosedNodes.push(nodeId);
+          Sitemap.setClosedNodesInLocalStorage(currentClosedNodes);
+          console.log(store.get(Ornament.C.Sitemap.storageKeys.closedNodeIds));
+        }
+      } else {
+        console.log(nodeId + " is open");
+        var nodeIndex = currentClosedNodes.indexOf(nodeId);
+        if(nodeIndex > -1)  {
+          console.log(nodeId + " removing from LS");
+          currentClosedNodes.splice(nodeIndex, 1);
+          Sitemap.setClosedNodesInLocalStorage(currentClosedNodes);
+          console.log(store.get(Ornament.C.Sitemap.storageKeys.closedNodeIds));
+        }
+      }
+    },
 
-    function render () {
-      return JSON.stringify ($rootItem.call ($toNestedSet));
-    }
+    closeNodes: function(arrayOfNodes){
+      $.each(arrayOfNodes, function(){
+        var $node = $("[data-node-id='" + this + "']");
+        $node.closest('li').addClass(Sitemap.closedNodeClass).removeClass(Sitemap.expandedNodeClass);
+        $node.children("span").addClass('ui-icon-plusthick').removeClass('ui-icon-minusthick');
+      });
+    },
 
-    function bindSortable () {
-      $rootList.not(".enabled").nestedSortable ({
-        forcePlaceholderSize: true
-      , handle: '.information'
-      , helper: 'clone'
-      , items: '.sortable'
-      , opacity: .6
-      , placeholder: 'placeholder'
-      , revert: 250
-      , tabSize: 32
-      , tolerance: 'pointer'
-      , toleranceElement: '> div'
-      , maxLevels: 0
-      , isTree: true
-      , startCollapsed: false
+    _$toNestedSet: function() {
+      var nodes = [];
+      var n = 1;
+
+      ! function () {
+        var $this = $ (this);
+        var node = { id: $this.data ('id'), parent_id: $this.componentOf ().data ('id') };
+
+        node.lft = n ++;
+        $ (this).components ('.nav-item.application').each (arguments.callee);
+        node.rgt = n ++;
+
+        nodes.push (node);
+      }.call (this);
+
+      return nodes;
+    },
+
+    _bindSortableTree: function($rootList) {
+      Sitemap.$rootList.not(".enabled").nestedSortable ({
+        forcePlaceholderSize: true,
+        handle: '.information',
+        helper: 'clone',
+        items: '.sortable',
+        opacity: .6,
+        placeholder: 'placeholder',
+        revert: 250,
+        tabSize: 32,
+        tolerance: 'pointer',
+        toleranceElement: '> div',
+        maxLevels: 0,
+        isTree: true,
+        startCollapsed: false
       })
       .addClass("enabled")
-      .on ("sortupdate", save);
+      .on ("sortupdate", Sitemap._saveSort);
+    },
 
-      $('.disclose').off('click').on('click', function() {
-        $(this).closest('li').toggleClass('mjs-nestedSortable-collapsed').toggleClass('mjs-nestedSortable-expanded');
-        $(this).children("span").toggleClass('ui-icon-plusthick').toggleClass('ui-icon-minusthick');
-      });
-    }
+    _saveSort: function(cb){
+      $.post (Sitemap.savePath, { set: Sitemap._renderAsJSON() }, cb);
+    },
 
-    $(document).on("ornament:koi:sitemap:unlocked", function(){
-      bindSortable();
-    });
+    _toggleNodeEvent: function(e) {
+      e.preventDefault();
+      Sitemap.toggleNode($(e.target));
+    },
 
-    $(document).on("ornament:koi:sitemap:locked", function(){
-      $rootList.removeClass("enabled").nestedSortable("destroy");
-    });
+    _bindToggleButtons: function(){
+      Sitemap.$tree.find('.disclose').off('click').on('click', Sitemap._toggleNodeEvent);
+    },
 
-    Ornament.bindSitemapSortable = function(){
-      $rootList.removeClass("enabled").nestedSortable("destroy");
-      $(".disclose").children("span").removeClass("ui-icon-plusthick").addClass("ui-icon-minusthick");
-      bindSortable();
-    }
+    _renderAsJSON: function(){
+      return JSON.stringify (Sitemap.$rootItem.call (Sitemap._$toNestedSet));
+    },
 
-    bindSortable();
+    _lockButtonEvent: function(e){
+      e.preventDefault();
+      Sitemap.toggleSitemapDragState();
+    },
 
-    if(localStorage) {
-      // Set initial state
-      if(localStorage.koiSitemapDragDropDisabled) {
-        koiSetSitemapDragDropState("disabled");
-      } else {
-        koiSetSitemapDragDropState("enabled");
-      }
+    init: function(){
+      // Find elements on the page
+      Sitemap.$lockButton = $(Sitemap.selectors.lockButtonSelector);
+      Sitemap.$tree = $(Sitemap.selectors.tree);
+
       // Button press action
-      $lockButton.on("click", function(e) {
-        e.preventDefault();
-        toggleKoiSitemapDragDropState();
+      Sitemap.$lockButton.on("click", Sitemap._lockButtonEvent);
+
+      // Bind sitemap functions
+      Sitemap.$tree.each(function() {
+        var $sitemap  = $(this);
+        var path      = $sitemap.data ('uri-save');
+        var $rootList = $sitemap.find ('.sitemap--root');
+        var $rootItem = $sitemap.component ('.nav-item');
+
+        // Expose to API
+        Sitemap.$rootList = $rootList;
+        Sitemap.$rootItem = $rootItem;
+        Sitemap.savePath = path;
+
+        // Bind sortable on list
+        Sitemap._bindSortableTree();
+        Sitemap._bindToggleButtons();
+
+        // Set initial state if LocalStorage is available
+        if(Sitemap.getLockedStateFromLocalStorage()) {
+          Sitemap.setSitemapDragStateDisabled();
+        } else {
+          Sitemap.setSitemapDragStateEnabled();
+        }
+
+        // Close the nodes set in localStorage
+        var existingHiddenNodes = Sitemap.getClosedNodesFromLocalStorage();
+        if(existingHiddenNodes) {
+          Sitemap.closeNodes(existingHiddenNodes);
+        }
       });
     }
 
-  });
+  }
+
+  Sitemap.init();
 });

--- a/app/assets/javascripts/koi/nav_items.js
+++ b/app/assets/javascripts/koi/nav_items.js
@@ -3,6 +3,7 @@ $(document).on("ornament:refresh", function(){
   var Sitemap = Ornament.C.Sitemap = {
 
     // Configuration
+    logging: true,
     disabledButtonClass: "button__depressed",
     closedNodeClass: 'mjs-nestedSortable-collapsed',
     expandedNodeClass: 'mjs-nestedSortable-expanded',
@@ -17,6 +18,12 @@ $(document).on("ornament:refresh", function(){
     lang: {
       enabledButton: "Lock Dragging",
       disabledButton: "Unlock Dragging"
+    },
+
+    log: function(log){
+      if(Sitemap.logging) {
+        console.log("[SITEMAP]", log);
+      }
     },
 
     getLockedStateFromLocalStorage: function(){
@@ -39,7 +46,7 @@ $(document).on("ornament:refresh", function(){
       } else {
         Sitemap.setSitemapDragStateDisabled();
       }
-  },
+    },
 
     // Disable dragging of sitemap
     setSitemapDragStateDisabled: function(){
@@ -75,21 +82,21 @@ $(document).on("ornament:refresh", function(){
       $container.toggleClass(Sitemap.closedNodeClass).toggleClass(Sitemap.expandedNodeClass);
       $label.toggleClass('ui-icon-plusthick').toggleClass('ui-icon-minusthick');
       if($container.hasClass(Sitemap.closedNodeClass)) {
-        console.log(nodeId + " is closed");
+        Sitemap.log(nodeId + " is closed");
         if(currentClosedNodes.indexOf(nodeId) === -1) {
-          console.log(nodeId + " adding to LS");
+          Sitemap.log(nodeId + " adding to LS");
           currentClosedNodes.push(nodeId);
           Sitemap.setClosedNodesInLocalStorage(currentClosedNodes);
-          console.log(store.get(Ornament.C.Sitemap.storageKeys.closedNodeIds));
+          Sitemap.log(store.get(Ornament.C.Sitemap.storageKeys.closedNodeIds));
         }
       } else {
-        console.log(nodeId + " is open");
+        Sitemap.log(nodeId + " is open");
         var nodeIndex = currentClosedNodes.indexOf(nodeId);
         if(nodeIndex > -1)  {
-          console.log(nodeId + " removing from LS");
+          Sitemap.log(nodeId + " removing from LS");
           currentClosedNodes.splice(nodeIndex, 1);
           Sitemap.setClosedNodesInLocalStorage(currentClosedNodes);
-          console.log(store.get(Ornament.C.Sitemap.storageKeys.closedNodeIds));
+          Sitemap.log(store.get(Ornament.C.Sitemap.storageKeys.closedNodeIds));
         }
       }
     },

--- a/app/views/koi/nav_items/_nav_item.html.erb
+++ b/app/views/koi/nav_items/_nav_item.html.erb
@@ -23,7 +23,7 @@
       <div class="nav-item--body">
 
         <%- if Koi::Sitemap.toggles -%>
-          <span title="Click to show/hide children" class="disclose">
+          <span title="Click to show/hide children" class="disclose" data-node-id="<%= nav_item.id -%>">
             <span class="ui-icon ui-icon-minusthick">Toggle</span>
           </span>
         <%- end -%>

--- a/vendor/assets/javascripts/koi/store.js
+++ b/vendor/assets/javascripts/koi/store.js
@@ -1,0 +1,191 @@
+"use strict"
+// Module export pattern from
+// https://github.com/umdjs/umd/blob/master/returnExports.js
+;(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.store = factory();
+  }
+}(this, function () {
+  
+  // Store.js
+  var store = {},
+    win = (typeof window != 'undefined' ? window : global),
+    doc = win.document,
+    localStorageName = 'localStorage',
+    scriptTag = 'script',
+    storage
+
+  store.disabled = false
+  store.version = '1.3.20'
+  store.set = function(key, value) {}
+  store.get = function(key, defaultVal) {}
+  store.has = function(key) { return store.get(key) !== undefined }
+  store.remove = function(key) {}
+  store.clear = function() {}
+  store.transact = function(key, defaultVal, transactionFn) {
+    if (transactionFn == null) {
+      transactionFn = defaultVal
+      defaultVal = null
+    }
+    if (defaultVal == null) {
+      defaultVal = {}
+    }
+    var val = store.get(key, defaultVal)
+    transactionFn(val)
+    store.set(key, val)
+  }
+  store.getAll = function() {}
+  store.forEach = function() {}
+
+  store.serialize = function(value) {
+    return JSON.stringify(value)
+  }
+  store.deserialize = function(value) {
+    if (typeof value != 'string') { return undefined }
+    try { return JSON.parse(value) }
+    catch(e) { return value || undefined }
+  }
+
+  // Functions to encapsulate questionable FireFox 3.6.13 behavior
+  // when about.config::dom.storage.enabled === false
+  // See https://github.com/marcuswestin/store.js/issues#issue/13
+  function isLocalStorageNameSupported() {
+    try { return (localStorageName in win && win[localStorageName]) }
+    catch(err) { return false }
+  }
+
+  if (isLocalStorageNameSupported()) {
+    storage = win[localStorageName]
+    store.set = function(key, val) {
+      if (val === undefined) { return store.remove(key) }
+      storage.setItem(key, store.serialize(val))
+      return val
+    }
+    store.get = function(key, defaultVal) {
+      var val = store.deserialize(storage.getItem(key))
+      return (val === undefined ? defaultVal : val)
+    }
+    store.remove = function(key) { storage.removeItem(key) }
+    store.clear = function() { storage.clear() }
+    store.getAll = function() {
+      var ret = {}
+      store.forEach(function(key, val) {
+        ret[key] = val
+      })
+      return ret
+    }
+    store.forEach = function(callback) {
+      for (var i=0; i<storage.length; i++) {
+        var key = storage.key(i)
+        callback(key, store.get(key))
+      }
+    }
+  } else if (doc && doc.documentElement.addBehavior) {
+    var storageOwner,
+      storageContainer
+    // Since #userData storage applies only to specific paths, we need to
+    // somehow link our data to a specific path.  We choose /favicon.ico
+    // as a pretty safe option, since all browsers already make a request to
+    // this URL anyway and being a 404 will not hurt us here.  We wrap an
+    // iframe pointing to the favicon in an ActiveXObject(htmlfile) object
+    // (see: http://msdn.microsoft.com/en-us/library/aa752574(v=VS.85).aspx)
+    // since the iframe access rules appear to allow direct access and
+    // manipulation of the document element, even for a 404 page.  This
+    // document can be used instead of the current document (which would
+    // have been limited to the current path) to perform #userData storage.
+    try {
+      storageContainer = new ActiveXObject('htmlfile')
+      storageContainer.open()
+      storageContainer.write('<'+scriptTag+'>document.w=window</'+scriptTag+'><iframe src="/favicon.ico"></iframe>')
+      storageContainer.close()
+      storageOwner = storageContainer.w.frames[0].document
+      storage = storageOwner.createElement('div')
+    } catch(e) {
+      // somehow ActiveXObject instantiation failed (perhaps some special
+      // security settings or otherwse), fall back to per-path storage
+      storage = doc.createElement('div')
+      storageOwner = doc.body
+    }
+    var withIEStorage = function(storeFunction) {
+      return function() {
+        var args = Array.prototype.slice.call(arguments, 0)
+        args.unshift(storage)
+        // See http://msdn.microsoft.com/en-us/library/ms531081(v=VS.85).aspx
+        // and http://msdn.microsoft.com/en-us/library/ms531424(v=VS.85).aspx
+        storageOwner.appendChild(storage)
+        storage.addBehavior('#default#userData')
+        storage.load(localStorageName)
+        var result = storeFunction.apply(store, args)
+        storageOwner.removeChild(storage)
+        return result
+      }
+    }
+
+    // In IE7, keys cannot start with a digit or contain certain chars.
+    // See https://github.com/marcuswestin/store.js/issues/40
+    // See https://github.com/marcuswestin/store.js/issues/83
+    var forbiddenCharsRegex = new RegExp("[!\"#$%&'()*+,/\\\\:;<=>?@[\\]^`{|}~]", "g")
+    var ieKeyFix = function(key) {
+      return key.replace(/^d/, '___$&').replace(forbiddenCharsRegex, '___')
+    }
+    store.set = withIEStorage(function(storage, key, val) {
+      key = ieKeyFix(key)
+      if (val === undefined) { return store.remove(key) }
+      storage.setAttribute(key, store.serialize(val))
+      storage.save(localStorageName)
+      return val
+    })
+    store.get = withIEStorage(function(storage, key, defaultVal) {
+      key = ieKeyFix(key)
+      var val = store.deserialize(storage.getAttribute(key))
+      return (val === undefined ? defaultVal : val)
+    })
+    store.remove = withIEStorage(function(storage, key) {
+      key = ieKeyFix(key)
+      storage.removeAttribute(key)
+      storage.save(localStorageName)
+    })
+    store.clear = withIEStorage(function(storage) {
+      var attributes = storage.XMLDocument.documentElement.attributes
+      storage.load(localStorageName)
+      for (var i=attributes.length-1; i>=0; i--) {
+        storage.removeAttribute(attributes[i].name)
+      }
+      storage.save(localStorageName)
+    })
+    store.getAll = function(storage) {
+      var ret = {}
+      store.forEach(function(key, val) {
+        ret[key] = val
+      })
+      return ret
+    }
+    store.forEach = withIEStorage(function(storage, callback) {
+      var attributes = storage.XMLDocument.documentElement.attributes
+      for (var i=0, attr; attr=attributes[i]; ++i) {
+        callback(attr.name, store.deserialize(storage.getAttribute(attr.name)))
+      }
+    })
+  }
+
+  try {
+    var testKey = '__storejs__'
+    store.set(testKey, testKey)
+    if (store.get(testKey) != testKey) { store.disabled = true }
+    store.remove(testKey)
+  } catch(e) {
+    store.disabled = true
+  }
+  store.enabled = !store.disabled
+  
+  return store
+}));


### PR DESCRIPTION
Now when a user closes a navitem in the sitemap it will remember their selections in localStorage and reflect this when they come back to the sitemap next time. 

As part of this, I rewrote the `nav_items.js` to be much more readable and exposed some public functions to the `Ornament.C` API:

```js
// See all the commands available
Ornament.C.Sitemap

// Debugging
Ornament.C.Sitemap.logging = true; // will turn on logging to output debug info to the console

// Read from user local storage
Ornament.C.Sitemap.getLockedStateFromLocalStorage(); // find out if the sitemap is locked or not
Ornament.C.Sitemap.getClosedNodesFromLocalStorage(); // get array of currently closed nodes
Ornament.C.Sitemap.setClosedNodesInLocalStorage([1,2,3]); // update local storage closed nodes

// Drag and drop states
Ornament.C.Sitemap.toggleSitemapDragState(); // turn drag/drop functions on/off
Ornament.C.Sitemap.setSitemapDragStateDisabled(); // disable dragging/dropping
Ornament.C.Sitemap.setSitemapDragStateEnabled(); // enable dragging/dropping

// Toggles
Ornament.C.Sitemap.toggleNode($nodeToggleElement); // toggle a node element on or off
Ornament.C.Sitemap.closeNodes([1,2,3]); // close an array of node ids
```

Unsure if these will ever be helpful but I like exposing public functions so we can do cool stuff. 