### PR TITLE
Mobile Pagination Select Menu

### DIFF
--- a/app/assets/javascripts/koi/components/select-link.js
+++ b/app/assets/javascripts/koi/components/select-link.js
@@ -7,28 +7,34 @@
 
   $(document).on("ornament:refresh", function () {
 
-    var $linkableSelects = $("[data-select-link]");
-    var currentUrl = document.location.pathname;
+    var SelectLinks = Ornament.C.SelectLinks = {
 
-    // On click change
-    $linkableSelects.each(function(){
-
-      var $thisSelect = $(this);
-
-      $thisSelect.on("change", function(){
-        var url = $thisSelect.val();
-        if(url != "") {
-          document.location = url;
+      markAsActiveForUrl: function($select, url) {
+        if ( $select.find("option[value='"+url+"']").length > 0 ) {
+          $select.val(url);
         }
-      });
+      },
 
-      // Default state
-      if ( $thisSelect.find("option[value='"+currentUrl+"']").length > 0 ) {
-        $thisSelect.val(currentUrl);
+      bindSelectLink: function($select){
+        $select.on("change", function(){
+          var url = $select.val();
+          if(url != "") {
+            document.location = url;
+          }
+        });
+        SelectLinks.markAsActiveForUrl($select, SelectLinks.currentUrl);
+      },
+
+      init: function(){
+        SelectLinks.$linkableSelects = $("[data-select-link]");
+        SelectLinks.currentUrl = document.location.pathname;
+        SelectLinks.$linkableSelects.each(function(){
+          SelectLinks.bindSelectLink($(this));
+        });
       }
+    }
 
-    });
-
+    SelectLinks.init();
   });
 
 }(document, window, jQuery));

--- a/app/views/kaminari/admin/_paginator.html.erb
+++ b/app/views/kaminari/admin/_paginator.html.erb
@@ -21,6 +21,11 @@
     </div>
     <div class="pagination--status">
       Page <%= current_page -%> of <%= total_pages -%>
+      <select data-select-link>
+        <% each_page do |page| -%>
+          <option value="<%= "#{@template.url_for}?#{params.merge(page: page.to_s).to_param}" -%>" <%= "selected" if page.to_s.eql?(current_page.to_s) -%>>Page <%= page -%></option>
+        <% end %>
+      </select>
     </div>
     <%= next_page_tag %>
     <%= last_page_tag %>

--- a/app/views/koi/admin_crud/_index_pagination_options.html.erb
+++ b/app/views/koi/admin_crud/_index_pagination_options.html.erb
@@ -3,7 +3,7 @@
     <% params[:per] = per_page.to_s if params[:per].blank? %>
     <% if page_list %>
       <% page_list.each do |per| %>
-          <%= link_to per.to_s.titleize, params.merge(:per => per), data: { get_script: true }, :class => "button button__small #{'button__primary' if params[:per] == per.to_s}" %>
+          <%= link_to per.to_s.titleize, params.merge(:per => per, :page => 1), data: { get_script: true }, :class => "button button__small #{'button__primary' if params[:per] == per.to_s}" %>
       <% end %>
     <% end %>
   </p>

--- a/app/views/koi/admin_crud/index.js.erb
+++ b/app/views/koi/admin_crud/index.js.erb
@@ -3,6 +3,7 @@ $('#index-fields').html('<%= escape_javascript(render("index_fields")) %>');
 <%- if is_paginated? -%>
 $('#index-pagination-options').html('<%= escape_javascript(render("index_pagination_options")) %>');
 $('#index-pagination').html('<%= escape_javascript(render("index_pagination")) %>');
+Ornament.C.SelectLinks.init();
 <%- end -%>
 
 $('#search_direction').attr('value', '<%= params[:direction] %>');


### PR DESCRIPTION
On desktop you get all pagination options, page links, first, previous, next and last. 
On mobile the next and previous links are retained and the pages are removed and only the next and previous links remain. 
I've improved the UX by adding a hidden select menu on mobile so that when you click on "Page X of Y" you can easily jump to another page:

![pagination-select](https://cloud.githubusercontent.com/assets/685024/23636549/e2b12b2a-0325-11e7-88e4-5335c4e75f94.jpg)

On the technical side, Kaminari has a [page_url_for(page) helper](https://github.com/kaminari/kaminari/blob/master/kaminari-core/lib/kaminari/helpers/tags.rb#L35) but it would not work, so I've kind of munged together the resultant URL. It works, but it feels weird to build up my own URL rather than get it from Kaminari. 