### PR TITLE
Redesigned Devise Views

### DIFF
--- a/app/assets/javascripts/koi/components/enhanced-form.js
+++ b/app/assets/javascripts/koi/components/enhanced-form.js
@@ -229,7 +229,8 @@
 
     _scaffoldPasswordRevealer: function($field){
       var $revealer = $("<button data-password-revealer-button />").attr("aria-label", "Toggle visibility of password").addClass("button button__icon").html(Ornament.icons.visible);
-      $revealer.off("click").on("click", function(){
+      $revealer.off("click").on("click", function(e){
+        e.preventDefault();
         FormHelpers._togglePasswordRevealer($field);
       });
       $field.wrap("<div class='form--password-revealer' />").after($revealer);

--- a/app/assets/stylesheets/koi/components/_devise.scss
+++ b/app/assets/stylesheets/koi/components/_devise.scss
@@ -38,3 +38,15 @@
   background: $light-grey;
   padding: $xxx-small-unit $panel-padding;
 }
+
+.devise .button-group {
+  @include media-query(450px) {
+    > div {
+      width: 100%;
+    }
+    a,button {
+      width: 100%;
+      text-align: center;
+    }
+  }
+}

--- a/app/assets/stylesheets/koi/components/_devise.scss
+++ b/app/assets/stylesheets/koi/components/_devise.scss
@@ -1,28 +1,40 @@
 .devise {
   padding-top: $large-unit;
+  padding-bottom: $large-unit;
+  min-height: 100%;
+  @include display-flex;
+  @include flex-direction(column);
+  @include align-items(center);
+  @include justify-content(center);
+}
+
+.devise--logo {
+  text-align: center;
+
+  h1 {
+    @include heading-one;
+  }
+}
+
+.devise--body .panel__notice {
+  border-bottom: 1px solid $border;
 }
 
 .devise--body {
   margin: 0 auto;
-  max-width: 500px;
+  width: 100%;
+  max-width: 320px;
   margin-top: $large-unit;
-}
-
-.devise .titlebar {
-  background: $black;
-  color: $white;
-  border-bottom: 5px solid $primary-color;
-  padding: $x-small-unit;
-  @include border-top-left-radius($border-radius);
-  @include border-top-right-radius($border-radius);
+  border: 1px solid $border;
 }
 
 .devise .bg-lightgrey {
   background: $x-light-grey;
-  padding: $x-small-unit;
+  padding: $panel-padding;
 }
 
 .devise .bg-mediumgrey {
+  border-top: 1px solid $border;
   background: $light-grey;
-  padding: $x-small-unit;
+  padding: $xxx-small-unit $panel-padding;
 }

--- a/app/assets/stylesheets/koi/components/_form.scss
+++ b/app/assets/stylesheets/koi/components/_form.scss
@@ -551,10 +551,19 @@ $file-thumbnail-width: 100px;
 
   button {
     position: absolute;
-    top: 4px;
-    bottom: 4px;
-    right: 4px;
+    top: 1px;
+    bottom: 1px;
+    right: 1px;
+    background: transparent;
     text-transform: uppercase;
     outline: none;
+  }
+
+  button,button:hover {
+    background: transparent;
+  }
+  
+  .button__icon path {
+    fill: $black;
   }
 }

--- a/app/views/admins/passwords/edit.html.erb
+++ b/app/views/admins/passwords/edit.html.erb
@@ -1,6 +1,4 @@
-<div class="titlebar">
-  <h2 class="heading-two">Change your password</h2>
-</div>
+<%- content_for :title, "Change your password" -%>
 
 <%= simple_form_for(resource, :as => resource_name, :url => koi_engine.admin_password_path, :html => { method: :put, class: "form-vertical" }) do |f| %>
 

--- a/app/views/admins/passwords/new.html.erb
+++ b/app/views/admins/passwords/new.html.erb
@@ -1,15 +1,20 @@
-<div class="titlebar">
-  <h2 class="heading-two">Password Reset</h2>
-</div>
+<%- content_for :title, "Password Reset" -%>
+
 <%= simple_form_for(resource, :as => resource_name, :url => koi_engine.admin_password_path, :html => { method: :post, class: "form-vertical" }) do |f| %>
   <div class="bg-lightgrey">
     <div class="inputs">
-      <%= f.input :email,required: true, autofocus: true, input_html: { class: "w-510" } %>
+      <%= f.input :email,required: true, autofocus: true, input_html: { class: "form--medium" } %>
     </div>
   </div>
   <div class="bg-mediumgrey">
-    <%= f.button :submit, "Reset", class: "button__primary" %>
-    <%= link_to "Back", koi_engine.new_admin_session_path, class: "button" %>
+    <div class="button-group">
+      <div>
+        <%= f.button :button, "Reset password", class: "button__success" %>
+      </div>
+      <div>
+        <%= link_to "Back", koi_engine.new_admin_session_path, class: "button" %>
+      </div>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -14,22 +14,26 @@
         <p class="error"><%= flash[:alert] %></p>
       <% end %>
 
-      <%= f.input :email, required: true, autofocus: true, input_html: { class: "w-510" } %>
+      <%= f.input :email, required: true, autofocus: true, input_html: { class: "form--medium" } %>
 
-      <%= f.input :password, required: true, input_html: { class: "w-510" } %>
+      <%= f.input :password, required: true, input_html: { class: "form--medium", data: { password_reveal: "" } } %>
 
-      <%= f.input :remember_me, as: :boolean, wrapper: :checkbox, wrapper_html: { class: "checkbox__single" }, label: "Keep me logged in on this computer" if devise_mapping.rememberable? %>
+      <%= f.input :remember_me, as: :boolean, wrapper: :checkbox, wrapper_html: { class: "checkbox__single form--enhanced" }, label: "Keep me logged in on this computer" if devise_mapping.rememberable? %>
 
     </div>
   </div>
 
   <div class="bg-mediumgrey">
-    <%= f.button :button, "Sign in", class: "button__primary" %>
-    <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
-      <%= link_to "Forgot your password?", koi_engine.new_admin_password_path, class: "button" %>
-    <% end -%>
-      <%#= render "devise/shared/links" %>
-    </ul>
+    <div class="button-group">
+      <div>
+        <%= f.button :button, "Sign in", class: "button__success" %>
+      </div>
+      <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
+        <div>
+          <%= link_to "Forgot your password?", koi_engine.new_admin_password_path, class: "button" %>
+        </div>
+      <% end -%>
+    </div>
   </div>
 
 <% end %>

--- a/app/views/layouts/koi/_icons.html.erb
+++ b/app/views/layouts/koi/_icons.html.erb
@@ -1,0 +1,9 @@
+<%- # Make icons accessible via JS -%>
+<div style="display: none;" data-ornament-icons>
+  <div data-ornament-icon-chevron><%= icon("chevron") -%></div>
+  <div data-ornament-icon-plus><%= icon("plus_thin") -%></div>
+  <div data-ornament-icon-close><%= icon("close") -%></div>
+  <div data-ornament-icon-spinner><%= icon("spinner") -%></div>
+  <div data-ornament-icon-visible><%= icon("visible") -%></div>
+  <div data-ornament-icon-hidden><%= icon("hidden") -%></div>
+</div>

--- a/app/views/layouts/koi/devise.html.erb
+++ b/app/views/layouts/koi/devise.html.erb
@@ -44,25 +44,17 @@
   <body>
 
     <div class="layout--container devise">
-      <div class="align-center">
-        <%= image_tag "koi/application/logo-katalyst-devise.png"%>
+      <div class="devise--logo">
+        <h1>Koi</h1>
+        <small>v<%= ::Koi::VERSION -%></small>
       </div>
       <div class="devise--body">
-        <%- if content_for?(:title) -%>
-          <div class="titlebar">
-            <h1 class="heading-two"><%= yield :title -%></h1>
-          </div>
-        <%- end -%>
         <%= render "/koi/shared/flash_messages" -%>
         <%= content_for?(:devise) ? yield(:devise) : yield %>
       </div>
     </div>
 
-    <%- # Make icons accessible via JS -%>
-    <div style="display: none;" data-ornament-icons>
-      <div data-ornament-icon-chevron><%= icon("chevron") -%></div>
-    </div>
-
+    <%= render "/layouts/koi/icons" -%>
 
   </body>
 </html>

--- a/app/views/layouts/koi/global.html.erb
+++ b/app/views/layouts/koi/global.html.erb
@@ -187,16 +187,7 @@
 
     </div>
 
-    <%- # Make icons accessible via JS -%>
-    <div style="display: none;" data-ornament-icons>
-      <div data-ornament-icon-chevron><%= icon("chevron") -%></div>
-      <div data-ornament-icon-plus><%= icon("plus_thin") -%></div>
-      <div data-ornament-icon-close><%= icon("close") -%></div>
-      <div data-ornament-icon-spinner><%= icon("spinner") -%></div>
-      <div data-ornament-icon-visible><%= icon("visible") -%></div>
-      <div data-ornament-icon-hidden><%= icon("hidden") -%></div>
-    </div>
-
+    <%= render "/layouts/koi/icons" -%>
     <%= yield :scripts_bottom %>
 
   </body>


### PR DESCRIPTION
Updated devise views (login, forgot password) to match redesign.

For testing purposes, temporarily disable the autologin:

```ruby
# test/dummy/app/controllers/common_controller_actions.rb:10
before_filter :sign_in_as_admin! if Rails.env.development?
```

RFC: https://github.com/katalyst/koi/issues/291