### PR TITLE
#307 - Pagination Fixes

### DIFF
--- a/app/views/kaminari/admin/_first_page.html.erb
+++ b/app/views/kaminari/admin/_first_page.html.erb
@@ -8,5 +8,5 @@
 -%>
 
 <div class="pagination--first <%= "disabled" if current_page.first? %>">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, title: "Go to first page" %>
+  <%= link_to_unless current_page.first?, raw(t 'views.koi.pagination.first'), url, :remote => remote, title: "Go to first page" %>
 </div>

--- a/app/views/kaminari/admin/_gap.html.erb
+++ b/app/views/kaminari/admin/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page pagination--gap"><%= raw(t 'views.pagination.truncate') %></span>
+<span class="page pagination--gap"><%= raw(t 'views.koi.pagination.truncate') %></span>

--- a/app/views/kaminari/admin/_last_page.html.erb
+++ b/app/views/kaminari/admin/_last_page.html.erb
@@ -8,6 +8,6 @@
 -%>
 
 <div class="pagination--last <%= "disabled" if current_page.last? -%>">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote, title: "Go to last page"} %>
+  <%= link_to_unless current_page.last?, raw(t 'views.koi.pagination.last'), url, {:remote => remote, title: "Go to last page"} %>
 </div>
 

--- a/app/views/kaminari/admin/_next_page.html.erb
+++ b/app/views/kaminari/admin/_next_page.html.erb
@@ -8,5 +8,5 @@
 -%>
 
 <div class="pagination--next <%= "disabled" if current_page.last? -%>">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, title: "Go to next page" %>
+  <%= link_to_unless current_page.last?, raw(t 'views.koi.pagination.next'), url, :rel => 'next', :remote => remote, title: "Go to next page" %>
 </div>

--- a/app/views/kaminari/admin/_prev_page.html.erb
+++ b/app/views/kaminari/admin/_prev_page.html.erb
@@ -8,6 +8,6 @@
 -%>
 
 <div class="pagination--previous <%= "disabled" if current_page.first? -%>">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, title: "Go to previous page" %>
+  <%= link_to_unless current_page.first?, raw(t 'views.koi.pagination.previous'), url, :rel => 'prev', :remote => remote, title: "Go to previous page" %>
 </div>
 

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,3 @@
+Kaminari.configure do |config|
+  config.outer_window = 1
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,9 +24,10 @@ en:
       nav_item:
         is_mobile: "Show for mobile"
   views:
-    pagination:
-      first: "« First"
-      last: "Last »"
-      previous: "‹ Prev"
-      next: "Next ›"
-      truncate: "..."
+    koi: 
+      pagination:
+        first: "« First"
+        last: "Last »"
+        previous: "‹ Prev"
+        next: "Next ›"
+        truncate: "..."


### PR DESCRIPTION
Fixes #307 

* Increased specificity of Koi language settings for pagination so that the application doesn't override Koi's (eg. uses `views.koi.pagination.first` rather than `views.pagination.first`)
* added kaminari initialiser to set outside_window to 1 so that first and last page numbers are shown