### PR TITLE
324 - Better Default Site Settings

### DIFF
--- a/app/controllers/koi/translations_controller.rb
+++ b/app/controllers/koi/translations_controller.rb
@@ -3,15 +3,11 @@ module Koi
     defaults :route_prefix => ''
 
     def seed
-      Translation.create(label: "Site Title", key: "site.title", value: "Site Title", field_type: "string", role: "Admin")
-      Translation.create(label: "Site Meta Description", key: "site.meta_description", value: "Meta Description", field_type: "text", role: "Admin")
-      Translation.create(label: "Site Meta Keywords", key: "site.meta_keywords", value: "Meta Keywords", field_type: "text", role: "Admin")
-      Translation.create(label: "Google Analytics", key: "site.google_analytics_embed", value: "<script></script>", field_type: "text", role: "Admin")
-      Translation.create(label: "Google Analytics Username", key: "site.google_analytics.username", value: "admin@katalyst.com.au", field_type: "string", role: "Admin")
-      Translation.create(label: "Google Analytics Password", key: "site.google_analytics.password", value: "yAw7c9rV", field_type: "string", role: "Admin")
-      Translation.create(label: "Google Analytics Profile ID", key: "site.google_analytics.profile_id", value: "UA-2161859-1", field_type: "string", role: "Admin")
-      Translation.create(label: "Twitter Search Query", key: "site.twitter.widget_id", value: "389900838295965696", field_type: "string", role: "Admin")
-      Translation.create(label: "Show Google Analytics", key: "site.show.dashboard.analytics", value: "true", field_type: "boolean", role: "Super")
+      Translation.create(label: "Site Title", key: "site.title", value: "", field_type: "string", role: "Admin")
+      Translation.create(label: "Site Meta Description", key: "site.meta_description", value: "", field_type: "text", role: "Admin")
+      Translation.create(label: "Site Meta Keywords", key: "site.meta_keywords", value: "", field_type: "text", role: "Admin")
+      Translation.create(label: "Google Analytics Profile ID", key: "site.google_analytics.profile_id", value: "", field_type: "string", role: "Admin")
+      Translation.create(label: "Twitter Search Query", key: "site.twitter.widget_id", value: "", field_type: "string", role: "Admin")
       redirect_to collection_path, notice: "Google Analytics and Twitter settings created."
     end
 

--- a/app/views/koi/application/_google_analytics.html.erb
+++ b/app/views/koi/application/_google_analytics.html.erb
@@ -1,33 +1,28 @@
-<% unless Translation.find_by_key('site.show.dashboard.analytics').try(:value).eql?("true") %>
-  <div class="island island__notice">
-    <p>Please set your google anlytics credentials <%= link_to "here", translations_path %></p>
-  </div>
-<% else %>
-  <% Report.analytics.destroy if params[:analytics].eql?("true") %>
-  <% report = Report.analytics %>
+<% Report.analytics.destroy if params[:analytics].eql?("true") %>
+<% report = Report.analytics %>
 
-  <div class="row">
-    <div class="span17">
-      <h2><small>Site traffic from <%= report.start_date %> to <%= report.end_date %></small></h2>
+<div class="row">
+  <div class="span17">
+    <h2><small>Site traffic from <%= report.start_date %> to <%= report.end_date %></small></h2>
+  </div>
+</div>
+
+<div class="row space-b-2">
+  <% Report::Humanize.each do |key, name| %>
+    <% value  = report.send("#{key}") %>
+    <% value  = value.round(2) if value.kind_of?(Float) %>
+    <% change = report.send("#{key}_diff") %>
+    <% change_text = change > 0 ? "increase" : "decrease" %>
+    <div class="widget span4 space-b-1">
+      <div class="widget-header"><%= name %></div>
+      <div class="widget-body"><%= number_with_delimiter value %></div>
+      <div class="widget-footer widget-footer-<%= change_text %>"><%= change.abs %>% <%= change_text %></div>
     </div>
-  </div>
+  <% end %>
+</div>
 
-  <div class="row space-b-2">
-    <% Report::Humanize.each do |key, name| %>
-      <% value  = report.send("#{key}") %>
-      <% value  = value.round(2) if value.kind_of?(Float) %>
-      <% change = report.send("#{key}_diff") %>
-      <% change_text = change > 0 ? "increase" : "decrease" %>
-      <div class="widget span4 space-b-1">
-        <div class="widget-header"><%= name %></div>
-        <div class="widget-body"><%= number_with_delimiter value %></div>
-        <div class="widget-footer widget-footer-<%= change_text %>"><%= change.abs %>% <%= change_text %></div>
-      </div>
-    <% end %>
-  </div>
+<div class="row  space-b-2">
+  <div class="span14"><i class="icon-refresh"></i> <strong><%= link_to "Refresh data", "?analytics=true" %></strong></div>
+  <div class="3"><i class="icon-signal"></i> <strong><a href="http://www.google.com/analytics/" target="_blank">Full analytics</a></strong></div>
+</div>
 
-  <div class="row  space-b-2">
-    <div class="span14"><i class="icon-refresh"></i> <strong><%= link_to "Refresh data", "?analytics=true" %></strong></div>
-    <div class="3"><i class="icon-signal"></i> <strong><a href="http://www.google.com/analytics/" target="_blank">Full analytics</a></strong></div>
-  </div>
-<% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,12 +34,8 @@ AliasNavItem.create!({ title: "Contact Us", alias_id: contact_us_page.id, parent
 Page.create!({ title: "Privacy Policy" }).to_navigator!(parent_id: footer.id)
 
 # Settings
-Translation.create!({ label: "Site Title", key: "site.title", value: "Site Title", field_type: "string", role: "Admin" })
-Translation.create!({ label: "Site Meta Description", key: "site.meta_description", value: "Meta Description", field_type: "text", role: "Admin" })
-Translation.create!({ label: "Site Meta Keywords", key: "site.meta_keywords", value: "Meta Keywords", field_type: "text", role: "Admin" })
-Translation.create!({ label: "Google Analytics", key: "site.google_analytics_embed", value: "<script></script>", field_type: "text", role: "Admin" })
-Translation.create!({ label: "Google Analytics Username", key: "site.google_analytics.username", value: "admin@katalyst.com.au", field_type: "string" , role: "Admin" })
-Translation.create!({ label: "Google Analytics Password", key: "site.google_analytics.password", value: "yAw7c9rV", field_type: "string", role: "Admin" })
-Translation.create!({ label: "Google Analytics Profile ID", key: "site.google_analytics.profile_id", value: "UA-2161859-1", field_type: "string", role: "Admin" })
-Translation.create!({ label: "Show Google Analytics", key: "site.show.dashboard.analytics", value: "true", field_type: "boolean", role: "Super" })
-Translation.create!({ label: "Twitter Search Query", key: "site.twitter.widget_id", value: "389900838295965696", field_type: "string", role: "Admin" })
+Translation.create!({ label: "Site Title", key: "site.title", value: "", field_type: "string", role: "Admin" })
+Translation.create!({ label: "Site Meta Description", key: "site.meta_description", value: "", field_type: "text", role: "Admin" })
+Translation.create!({ label: "Site Meta Keywords", key: "site.meta_keywords", value: "", field_type: "text", role: "Admin" })
+Translation.create!({ label: "Google Analytics Profile ID", key: "site.google_analytics.profile_id", value: "", field_type: "string", role: "Admin" })
+Translation.create!({ label: "Twitter Search Query", key: "site.twitter.widget_id", value: "", field_type: "string", role: "Admin" })

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
     <%= stylesheet_link_tag    "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
-    <%= raw t("site.google_analytics_embed", default: "") %>
   </head>
   <body>
 

--- a/test/dummy/app/views/layouts/mobile/application.html.erb
+++ b/test/dummy/app/views/layouts/mobile/application.html.erb
@@ -8,7 +8,6 @@
     <%= stylesheet_link_tag    "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
-    <%= raw t("site.google_analytics_embed", default: "") %>
   </head>
   <body>
 


### PR DESCRIPTION
Removed default values for:

* Site Title
* Meta Description
* Meta Keywords
* Google Analytics Profile ID
* Twitter Search Query

Outright removed these default settings:

* Google Analytics Embed Script
  - Removed in favour of only using the Profile ID as the hook to add the script to the front-end
* Show Google Analytics 
  - This was being used as a flag to show the Google Analytics dashboard reports. 
* Google Analytics Username
  - Was being used for the dashboard analytics
* Google Analytics Password
  - Was being used for the dashboard analytics

I've removed the Google Analytics dashboard view code as well since it's broken and no longer being used. It will be improved in the future with the Dashboard upgrade. 

See this RFC for more info:
https://github.com/katalyst/koi/issues/324

### Aside: Ornament integration 

It's worth noting I've added a few commits to Ornament to take advantage of the new settings:
* [Added Koi Site Settings support for title/description/keywords in SEO partial](https://github.com/katalyst/ornament/commit/d6cab83e1cddd5edecbc642a8b9fd3b79d4e7796)
* [Added Koi Site Settings support for Google Analytics script](https://github.com/katalyst/ornament/commit/e3e8a7e0264755a43d8d964cdfd95bf447445d60)

The goal here is moving some of the front-end configuration in to Koi. Now if the user adds a Analytics Profile ID it will push out to the front-end and add the script to the page. 
Similarly if a Site Title/Description/Keywords are added it will use that as a fallback instead of whatever fallbacks are defined in the SEO partial. 
