### PR TITLE
Settings: Image/File uploads alignment issue

### DIFF
--- a/app/views/koi/settings/_field_file.html.erb
+++ b/app/views/koi/settings/_field_file.html.erb
@@ -57,7 +57,7 @@
   </div>
 
   <div class="form--file-upload">
-    <div>
+    <div class="form--file-upload--body">
       <%= f.file_field(attr, class: html_class, data: {file_max_count: max_count, file_max_size: max_size, file_types: types, file_existing_image: existing_image, field: "hidden_for_#{attr}" }) %>
     </div>
   </div>

--- a/app/views/koi/settings/_field_image.html.erb
+++ b/app/views/koi/settings/_field_image.html.erb
@@ -57,7 +57,7 @@
   </div>
 
   <div class="form--file-upload">
-    <div>
+    <div class="form--file-upload--body">
       <%= f.file_field(attr, class: html_class, data: {file_max_count: max_count, file_max_size: max_size, file_types: types, file_existing_image: existing_image, field: "hidden_for_#{attr}" }) %>
     </div>
   </div>


### PR DESCRIPTION
Fixed the browse `button` element sitting over the label/hint for image/file uploads in settings. 