### PR TITLE
Orphaned Pages First Cut

### DIFF
--- a/app/controllers/koi/nav_items_controller.rb
+++ b/app/controllers/koi/nav_items_controller.rb
@@ -33,6 +33,7 @@ module Koi
 
     def sitemap
        @nav_items = NavItem.all
+       @orphan_pages = get_orphan_pages
     end
 
     def savesort

--- a/app/controllers/koi/pages_controller.rb
+++ b/app/controllers/koi/pages_controller.rb
@@ -9,5 +9,15 @@ module Koi
       end
     end
 
+    def orphans
+      @pages = get_orphan_pages.page(params[:page]).per(20)
+    end
+
+    def restore_orphan
+      @page = Page.find(params[:id])
+      @page.to_navigator!({ parent_id: NavItem.root.id })
+      redirect_to sitemap_nav_items_path
+    end
+
   end
 end

--- a/app/helpers/koi/application_helper.rb
+++ b/app/helpers/koi/application_helper.rb
@@ -153,4 +153,12 @@ module Koi::ApplicationHelper
     content_tag(:li, link_to(label, link_path, link_opts), li_opts)
   end
 
+  # Get all Pages that don't have an NavItem 
+  # Used to populate orphan pages list and to show the orphan pages 
+  # link on the sitemap page 
+  def get_orphan_pages
+    page_navids = NavItem.where(navigable_type: "Page").collect { |n| n.navigable_id }
+    Page.where(['id NOT IN (?)', page_navids])
+  end
+
 end

--- a/app/helpers/koi/application_helper.rb
+++ b/app/helpers/koi/application_helper.rb
@@ -157,8 +157,8 @@ module Koi::ApplicationHelper
   # Used to populate orphan pages list and to show the orphan pages 
   # link on the sitemap page 
   def get_orphan_pages
-    page_navids = NavItem.where(navigable_type: "Page").collect { |n| n.navigable_id }
-    Page.where(['id NOT IN (?)', page_navids])
+    page_navids = NavItem.where(navigable_type: "Page").pluck(:navigable_id)
+    Page.where.not(id: page_navids)
   end
 
 end

--- a/app/views/koi/nav_items/sitemap.html.erb
+++ b/app/views/koi/nav_items/sitemap.html.erb
@@ -16,15 +16,26 @@
 
 <% content_for :side do %>
 
-  <div class="content-spacing">
+  <div class="spacing">
 
     <%= render "lock_sitemap", panel_class: "sitemap--lock__desktop" -%>
 
-    <h2 class="heading-two">Adding a page</h2>
-    
-    <p>To select a new page move your cursor over the item above or the folder the page should be part of. Roll over the 'add' link and select 'page' to add the page. </p>
-    <p>After you have added the page, go back to the site map and move the page to the correct position.</p>
-    <p>More information can be found in the <%= link_to "help section", koi_engine.help_path %>.</p>
+    <div class="compressed">
+      <h2 class="heading-two">Adding a page</h2>
+      <p>To select a new page move your cursor over the item above or the folder the page should be part of. Roll over the 'add' link and select 'page' to add the page. </p>
+      <p>After you have added the page, go back to the site map and move the page to the correct position.</p>
+      <p>More information can be found in the <%= link_to "help section", koi_engine.help_path %>.</p>
+    </div>
+
+    <%- unless @orphan_pages.blank? -%>
+      <div class="compressed">
+        <h2 class="heading-two">Orphaned Pages</h2>
+        <p>There are <%= link_to "orphaned pages", orphans_pages_path -%> available to be restored.</p>
+        <p>Orphaned pages occur when link in the sitemap is deleted without deleting the page itself.</p>
+        <p>These pages are still available on the website and will still appear if accessed directly.</p>
+        <p><%= link_to "View orphaned pages", orphans_pages_path -%>.</p>
+      </div>
+    <%- end -%>
 
   </div>
 

--- a/app/views/koi/pages/orphans.html.erb
+++ b/app/views/koi/pages/orphans.html.erb
@@ -1,0 +1,58 @@
+<%- content_for :title, "Orphaned Pages" -%>
+
+<%- partial_with_wrapper do -%>
+  <%- content_for :below_title do -%>
+    <%= render partial: "index_below_title" -%>
+  <%- end -%>
+<%- end -%>
+
+<%= partial_with_wrapper do -%>
+  <div class="listing--above-list">
+    <%= render partial: "index_above_list" -%>
+  </div>
+<%- end -%>
+
+<%- if @pages.blank? -%>
+  <div class="panel panel--padding panel__notice compressed">
+    <p>You have no orphaned pages, yay!</p>
+  </div>
+<%- else -%>
+  <div id="index-fields" class="table-container">
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="table__th__id">Id</th>
+          <th>Page name</th>
+          <th class="table__th__actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%- @pages.each do |page| -%>
+          <tr>
+            <td>
+              <%= page.id -%>
+            </td>
+            <td>
+              <%= link_to page.title, edit_page_path(page) -%>
+            </td>
+            <td class="table__td__actions table--actions--container">
+              <%= link_to "Add to sitemap", restore_orphan_page_path(page) -%>
+            </td>
+          </tr>
+        <%- end -%>
+      </tbody>
+    </table>
+  </div>
+<%- end -%>
+
+<% if @pages.total_pages != 0 %>
+  <div id="index-pagination">
+    <%= render 'index_pagination' %>
+  </div>
+<% end %>
+
+<%= partial_with_wrapper do -%>
+  <div class="listing--below-list">
+    <%= render partial: "index_below_list" -%>
+  </div>
+<%- end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,14 @@ Koi::Engine.routes.draw do
   resources :settings do
     put  :update_multiple, on: :collection
   end
-  resources :pages
+  resources :pages do
+    collection do 
+      get :orphans
+    end
+    member do
+      get :restore_orphan
+    end
+  end
   resources :url_rewrites
   resources :friendly_id_slugs
   resources :admins, path: :site_users


### PR DESCRIPTION
This is a "front-end" attempt at Orphaned pages (#228). 

It would be good if we could tie it in to the admin_crud views so it can get search features and all the view enhancements without having to duplicate the code in to its own view. 

### Assumptions 

1. When orphans are adopted (awww) they get pushed to the bottom of the sitemap under the root navitem. This is, I think, the least destructive method as the Root NavItem should never be used on the front-end. This also makes them pretty easy to find afterwards. 

1. When clicking the restore button, the user is redirected to the sitemap. This might not be ideal if the user wants to adopt a family of orphans. I think this is probably an edge-case though. 

### How to test? 

1. Go to sitemap, find a page and click on modify. 
1. Delete the navitem
1. Refresh your sitemap, there's now an "Orphaned Pages" message. 
1. Click on the link in the message (alternatively, navigate to /admin/orphaned_pages) 
1. Click on "Restore to Sitemap" link to move it back to the bottom of the sitemap. 