### PR TITLE
Enabled some level of caching for nav item god tab functionalities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ PATH
       select2-rails (~> 3.5.9)
       sendgrid (~> 1.2.4)
       sidekiq (~> 5.0.0)
-      simple-navigation (~> 4.0.5)
+      simple-navigation (~> 3.14)
       simple_form
       uglifier (~> 3.2.0)
       uuidtools (~> 2.1.5)
@@ -302,7 +302,7 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.3, >= 3.3.3)
-    simple-navigation (4.0.5)
+    simple-navigation (3.14.0)
       activesupport (>= 2.3.2)
     slop (3.6.0)
     sprockets (3.7.1)

--- a/app/helpers/koi/navigation_helper.rb
+++ b/app/helpers/koi/navigation_helper.rb
@@ -12,6 +12,9 @@ module Koi::NavigationHelper
     request_path = request.path.parameterize if request.path
     cache_key = "#{request_path}_#{cache_key}"
 
+    # don't cache at this level if nav highlghts/if/unless etc is enabled
+    return get_render_navigation(nav_items_fetch_key, options) if Koi::Caching.god_nav_tab_enabled
+    # otherwise, cache the html output
     Rails.cache.fetch(prefix_cache_key(cache_key), expires_in: cache_expiry) do
       get_render_navigation(nav_items_fetch_key, options)
     end
@@ -24,6 +27,8 @@ module Koi::NavigationHelper
 
   def get_nav_items(key)
     if Koi::Caching.enabled
+      # don't cache at this level if nav highlghts/if/unless etc is enabled
+      return NavItem.navigation(key, binding()) if Koi::Caching.god_nav_tab_enabled
       Rails.cache.fetch(prefix_cache_key(key), expires_in: cache_expiry) do
         NavItem.navigation(key, binding())
       end

--- a/app/views/koi/nav_items/_modal_nav_item.html.erb
+++ b/app/views/koi/nav_items/_modal_nav_item.html.erb
@@ -23,9 +23,9 @@
           </li>
           <% if current_admin.god? %>
             <li><a href="#tab_advanced" class="tabs--link" data-tab="tab_advanced">Advanced</a></li>
-            <!--
+            <% if Koi::Caching.god_nav_tab_enabled %>
               <li><a href="#tab_god" class="tabs--link" data-tab="tab_god">God</a></li>
-            -->
+            <% end %>
           <% end %>
         </ul>
       </div>
@@ -41,9 +41,11 @@
         <div class="tabs--pane" id="tab_advanced" data-tab-for="tab_advanced">
           <%= render "advanced_form_fields", { f: f } %>
         </div>
-        <div class="tabs--pane" id="tab_god" data-tab-for="tab_god">
-          <%= render "god_form_fields", { f: f } %>
-        </div>
+        <% if Koi::Caching.god_nav_tab_enabled %>
+          <div class="tabs--pane" id="tab_god" data-tab-for="tab_god">
+            <%= render "god_form_fields", { f: f } %>
+          </div>
+        <% end %>
       <% end %>
     </div>
 

--- a/koi.gemspec
+++ b/koi.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'responders', '~> 2.4.0'
 
   # Navigation Rendering
-  s.add_dependency 'simple-navigation', '~> 4.0.5'
+  s.add_dependency 'simple-navigation', '~> 3.14'
 
   # Tags
   s.add_dependency 'acts-as-taggable-on', '~> 4.0.0'

--- a/lib/koi/caching.rb
+++ b/lib/koi/caching.rb
@@ -4,6 +4,9 @@ module Koi
     mattr_accessor :enabled
     @@enabled = true
 
+    mattr_accessor :god_nav_tab_enabled
+    @@god_nav_tab_enabled = false
+
     # Cache Expires in
     mattr_accessor :expires_in
     @@expires_in = 60.minutes

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -9,9 +9,23 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
+  # Show full error reports
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+
+  # Enable/disable caching. By default caching is disabled.
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.action_controller.perform_caching = true
+
+    config.cache_store = :memory_store
+    config.public_file_server.headers = {
+      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+    }
+  else
+    config.action_controller.perform_caching = false
+
+    config.cache_store = :null_store
+  end
+
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/test/dummy/config/initializers/koi.rb
+++ b/test/dummy/config/initializers/koi.rb
@@ -76,5 +76,23 @@ Koi::Sitemap.toggles = true
 # Caching enabled by default
 Koi::Caching.enabled = true
 
+# NAV ITEM GOD TAB
+#
+# Enable the 'god' tab when editing / creating nav items
+# This allows highlights_on/if/unless logic to be put in these fields.
+# e.g. if you want a nav item to show up only if a user is logged in and is rich,
+# you could put something like this in the "if" field:
+#
+#   user_signed_in? && current_user.is_rich?
+#
+# Or if you want a nav item to be highlighted when on a specific page, in the "highlights on"
+# field you could put:
+#
+#   request.path =~ /contact-form/
+#
+# Caveat: this enables a different, less robust form of caching, and should be avoided
+# on extremely traffic heavy sites.
+Koi::Caching.god_nav_tab_enabled = true
+
 # Expiry in 60.minutes by default
 Koi::Caching.expires_in = 5.minutes


### PR DESCRIPTION
Koi caching now has a `Koi::Caching.god_nav_tab_enabled` option. This allows super admins to access the 'god' tab when editing nav items, and allows the existing highlights_on / if / unless functionality, but with caching still turned on.

The form of caching is not nearly as good, but it'll still suffice for most of our sites. 
