### PR TITLE
Sitemap - Link navitem to first child

### DIFF
--- a/app/assets/stylesheets/koi/nav_items.scss
+++ b/app/assets/stylesheets/koi/nav_items.scss
@@ -108,6 +108,7 @@
   padding-right: 8px;
 }
 
+.nav-item--links-to-child,
 .nav-item--key,
 .nav-item--hidden {
   @include display-flex;
@@ -123,6 +124,16 @@
     path {
       fill: $grey;
     }
+  }
+
+  .icon--polygon,
+  svg path {
+    fill: $grey;
+  }
+
+  .icon--polyline,
+  svg path {
+    stroke: $grey;
   }
 }
 

--- a/app/models/folder_nav_item.rb
+++ b/app/models/folder_nav_item.rb
@@ -5,18 +5,19 @@ class FolderNavItem < NavItem
   validates :title, :parent, presence: true
 
   crud.config do
-    fields parent_id:     { type: :hidden },
-           is_hidden:     { type: :boolean },
-           alias_id:      { type: :tree },
-           if:            { type: :code },
-           unless:        { type: :code },
-           method:        { type: :code },
-           highlights_on: { type: :code },
-           content_block: { type: :code }
+    fields parent_id:           { type: :hidden },
+           is_hidden:           { type: :boolean },
+           link_to_first_child: { type: :boolean },
+           alias_id:            { type: :tree },
+           if:                  { type: :code },
+           unless:              { type: :code },
+           method:              { type: :code },
+           highlights_on:       { type: :code },
+           content_block:       { type: :code }
 
     config :admin do
       index fields: [:id, :title, :url]
-      form  fields: [:title, :url, :is_hidden, :parent_id]
+      form  fields: [:title, :url, :is_hidden, :link_to_first_child, :parent_id]
     end
   end
 

--- a/app/models/module_nav_item.rb
+++ b/app/models/module_nav_item.rb
@@ -5,18 +5,19 @@ class ModuleNavItem < NavItem
   validates :title, :url, :parent, presence: true
 
   crud.config do
-    fields parent_id:     { type: :hidden },
-           is_hidden:     { type: :boolean },
-           alias_id:      { type: :tree },
-           if:            { type: :code },
-           unless:        { type: :code },
-           method:        { type: :code },
-           highlights_on: { type: :code },
-           content_block: { type: :code }
+    fields parent_id:           { type: :hidden },
+           is_hidden:           { type: :boolean },
+           link_to_first_child: { type: :boolean },
+           alias_id:            { type: :tree },
+           if:                  { type: :code },
+           unless:              { type: :code },
+           method:              { type: :code },
+           highlights_on:       { type: :code },
+           content_block:       { type: :code }
 
     config :admin do
       index fields: [:id, :title, :url]
-      form  fields: [:title, :url, :is_hidden, :parent_id]
+      form  fields: [:title, :url, :is_hidden, :link_to_first_child, :parent_id]
     end
   end
 

--- a/app/models/nav_item.rb
+++ b/app/models/nav_item.rb
@@ -8,18 +8,19 @@ class NavItem < ActiveRecord::Base
   has_crud searchable: [:id, :title, :url], settings: false
 
   crud.config do
-    fields parent_id:     { type: :hidden },
-           is_hidden:     { type: :boolean },
-           alias_id:      { type: :tree },
-           if:            { type: :code },
-           unless:        { type: :code },
-           method:        { type: :code },
-           highlights_on: { type: :code },
-           content_block: { type: :code }
+    fields parent_id:           { type: :hidden },
+           is_hidden:           { type: :boolean },
+           link_to_first_child: { type: :boolean },
+           alias_id:            { type: :tree },
+           if:                  { type: :code },
+           unless:              { type: :code },
+           method:              { type: :code },
+           highlights_on:       { type: :code },
+           content_block:       { type: :code }
 
     config :admin do
       index fields: [:id, :title, :url]
-      form  fields: [:title, :url, :is_hidden, :parent_id]
+      form  fields: [:title, :url, :is_hidden, :link_to_first_child, :parent_id]
     end
   end
 
@@ -97,6 +98,12 @@ class NavItem < ActiveRecord::Base
 
     unless options.blank?
       hash[:options] = options
+    end
+
+    if link_to_first_child?
+      if children.present?
+        hash[:url] = children.first.url
+      end
     end
 
     hash

--- a/app/models/resource_nav_item.rb
+++ b/app/models/resource_nav_item.rb
@@ -7,18 +7,19 @@ class ResourceNavItem < NavItem
   validates :title, :parent, :url, :admin_url, presence: true
 
   crud.config do
-    fields parent_id:     { type: :hidden },
-           is_hidden:     { type: :boolean },
-           alias_id:      { type: :tree },
-           if:            { type: :code },
-           unless:        { type: :code },
-           method:        { type: :code },
-           highlights_on: { type: :code },
-           content_block: { type: :code }
+    fields parent_id:           { type: :hidden },
+           is_hidden:           { type: :boolean },
+           link_to_first_child: { type: :boolean },
+           alias_id:            { type: :tree },
+           if:                  { type: :code },
+           unless:              { type: :code },
+           method:              { type: :code },
+           highlights_on:       { type: :code },
+           content_block:       { type: :code }
 
     config :admin do
       index fields: [:id, :title, :url]
-      form  fields: [:title, :url, :is_hidden, :parent_id]
+      form  fields: [:title, :url, :is_hidden, :link_to_first_child, :parent_id]
     end
   end
 

--- a/app/views/koi/nav_items/_nav_item.html.erb
+++ b/app/views/koi/nav_items/_nav_item.html.erb
@@ -58,6 +58,12 @@
               </div>
             <%- end -%>
 
+            <%- if nav_item.read_attribute(:link_to_first_child) -%>
+              <div class="nav-item--links-to-child" title="This navitem will link to it's first child">
+                <%= icon("links_to_child") -%>
+              </div>
+            <%- end -%>
+
           <%- end -%>
         </div>
 

--- a/app/views/koi/nav_items/_nav_item.html.erb
+++ b/app/views/koi/nav_items/_nav_item.html.erb
@@ -1,9 +1,9 @@
 <%# cache "nav_item/admin/#{nav_item.id}-#{nav_item.updated_at}/sitemap", expires_in: 7.days do %>
 
   <%
-    nav_item_type = nav_item.class.name.underscore.dasherize 
-    nav_item_id = nav_item.id 
-    nav_item_is_hidden = nav_item.read_attribute(:is_hidden) == true
+    nav_item_type = nav_item.class.name.underscore.dasherize
+    nav_item_id = nav_item.id
+    nav_item_is_hidden = nav_item.is_hidden?
     is_root_nav_item = nav_item.is_a?(RootNavItem)
   %>
 
@@ -58,7 +58,7 @@
               </div>
             <%- end -%>
 
-            <%- if nav_item.read_attribute(:link_to_first_child) -%>
+            <%- if nav_item.link_to_first_child? -%>
               <div class="nav-item--links-to-child" title="This navitem will link to it's first child">
                 <%= icon("links_to_child") -%>
               </div>

--- a/app/views/koi/shared/icons/_links_to_child.html.erb
+++ b/app/views/koi/shared/icons/_links_to_child.html.erb
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 12 12" width='<%= options[:width] -%>' height='<%= options[:height] -%>' class="icon-links-to-child">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="child">
+          <polygon id="Rectangle" fill="#000000" transform="translate(7.489277, 7.250000) rotate(-45.000000) translate(-7.489277, -7.250000) " points="4.4916554 3.89882531 10.8556164 10.2627863 4.12293696 10.6011747" class="icon--polygon"></polygon>
+          <polyline id="Path-2" stroke="#000000" stroke-width="1.5" points="0 2.5 7.5 2.5 7.5 7" class="icon--polyline"></polyline>
+        </g>
+    </g>
+</svg>

--- a/db/migrate/20170915073755_add_link_to_child_to_nav_item.rb
+++ b/db/migrate/20170915073755_add_link_to_child_to_nav_item.rb
@@ -1,0 +1,5 @@
+class AddLinkToChildToNavItem < ActiveRecord::Migration
+  def change
+    add_column :nav_items, :link_to_first_child, :boolean
+  end
+end

--- a/test/dummy/db/migrate/20170915073755_add_link_to_child_to_nav_item.rb
+++ b/test/dummy/db/migrate/20170915073755_add_link_to_child_to_nav_item.rb
@@ -1,0 +1,5 @@
+class AddLinkToChildToNavItem < ActiveRecord::Migration
+  def change
+    add_column :nav_items, :link_to_first_child, :boolean
+  end
+end


### PR DESCRIPTION
We have a common use-case where we have top-level navigation that actually links to the first of their child navigation, eg:

```
about_us - this actually links to the 'about_us' below
  about_us
  our team
  contact us
```

Normally we solve this by creating a module navitem with a URL pointing to the first child navitem.   
That solution works okay but it's not very flexible and can be confusing for some people.   

This solution adds a "Link to first child" tick-box in the navitem modify menu, which automatically overrides the url passed in to simple form as the first child url instead. 

The sitemap shows a handy-dandy icon to represent redirected navitems:

![screen shot 2017-09-18 at 9 23 40 am](https://user-images.githubusercontent.com/685024/30526074-15e95604-9c53-11e7-9c4c-597aea09da40.png)


### Alias navitems

I made the conscious decision to not add this to alias navitems, since the alias navitem is already all about redirecting. It might be worth adding for the sake of consistency, but it might be confusing as to what a redirected alias is actually doing. 

### What if the parent has no children?

The tickbox can still be ticked and the icon will still show, but the behaviour will be ignored and the navitem will still link to it's set URL. 

### Moving navitems? 

The navitem will automatically update it's URL to point to the first child when moving the navitems around. Have you changed what the first child is? No worries! It points to the new one! 
The code is generated when the navitems are built (and cached) so if you notice irregular behaviour it should be as simple as refreshing the Koi cache. 