### PR TITLE
Missing CommonControllerActions in PagesController

### DIFF
--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -215,7 +215,7 @@ END
 
 # import Pages controller
 create_file 'app/controllers/pages_controller.rb', <<-END
-class PagesController < Koi::CrudController
+class PagesController < CrudController
 
   # Stop accidental leakage of unwanted actions to frontend
 


### PR DESCRIPTION
Just a quick one to fix the generated `pages_controller.rb` inheriting from `Koi::CrudController` rather than `CrudController`. 