### PR TITLE
fixed nice_tags field type for rails 4 & new acts_as_taggable version

### DIFF
--- a/app/views/koi/admin_crud/_form_field_nice_tags.html.erb
+++ b/app/views/koi/admin_crud/_form_field_nice_tags.html.erb
@@ -1,11 +1,19 @@
-<%- id = "koi-#{ new_uuid }" -%>
-<%= f.input attr, as: :string, wrapper_html: { class: "form--medium" }, input_html: { id: id } %>
+<%
+  id            = "koi-#{ new_uuid }"
+  klass         = f.object.class
+  tag_list_name = attr.to_s.chomp('_list')
+
+  tag_counts  = klass.tag_counts_on(tag_list_name)
+  tag_counts += klass.tag_counts_on(tag_list_name.pluralize)
+%>
+
+<%= f.input attr, as: :string, wrapper_html: { class: "form--medium" }, input_html: { id: id, value: f.object.send(attr).join(',') } %>
 
 <%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>
 
 <script type='text/javascript'>
   $("#<%= id %>").select2({
-  	tags: <%= raw f.object.class.tag_counts_on(attr.to_s.chomp('_list')).collect { |t| t.name } %>,
+  	tags: <%= raw tag_counts.map(&:name) %>,
     tokenSeparators: [","]
   });
 </script>

--- a/test/dummy/app/models/product.rb
+++ b/test/dummy/app/models/product.rb
@@ -52,7 +52,7 @@ class Product < ActiveRecord::Base
 
     config :admin do
       index fields: [:name]
-       form  fields: [:name, :description, :launch_date, :colour, :products, :product_images]
+       form  fields: [:name, :description, :launch_date, :colour, :products, :product_images, :genre_list]
     end
   end
 


### PR DESCRIPTION
- it should no longer merge tags after saving
- autocomplete should now work regardless of the name of your tag field