### PR TITLE
Fix for postgres 1.0.0 release breaking bootstrapping process

### DIFF
--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -88,6 +88,9 @@ gem_group :development do
   gem 'rack-mini-profiler'
 end
 
+# Forcing Postgres version to fix release issues with 1.0.0
+gsub_file "Gemfile", "gem 'pg'", "gem 'pg', '~> 0.21'"
+
 # Setup mailer host
 application(nil, :env => 'development') do
   "config.action_mailer.asset_host = \"http://localhost:3000\""


### PR DESCRIPTION
* The release of postgres 1.0.0 has broken `rails new -d postgres`
* The pg gem is added to the gemfile via the `rails new` command, it's not something added by Koi
* Tried adding `'pg', '0.21'` as another gem in app.rb, that results in two pg gems and bundle won't bundle
* Tried locking pg's gem version in Koi's Gemfile.lock or specifying the version in Koi's gemspec, didn't have any affect on the resulting Gemfile, it always resulted in just `gem 'pg'` which bundled to version 1.0.0
* I couldn't find any method of overriding the postgres version that gets generated, the best option I could find was to gsub replace during bootstrap