### PR TITLE
Switching to new mailtrap domain

### DIFF
--- a/lib/templates/application/app.rb
+++ b/lib/templates/application/app.rb
@@ -477,8 +477,8 @@ else
   ActionMailer::Base.smtp_settings = {
     user_name: Figaro.env.mailtrap_username,
     password: Figaro.env.mailtrap_password,
-    address: 'mailtrap.io',
-    domain: 'mailtrap.io',
+    address: 'smtp.mailtrap.io',
+    domain: 'smtp.mailtrap.io',
     port: '2525',
     authentication: :cram_md5,
     enable_starttls_auto: true

--- a/test/dummy/config/initializers/setup_smtp.rb
+++ b/test/dummy/config/initializers/setup_smtp.rb
@@ -18,8 +18,8 @@ else
   ActionMailer::Base.smtp_settings = {
     user_name: ENV["MAILTRAP_USERNAME"],
     password: ENV["MAILTRAP_PASSWORD"],
-    address: 'mailtrap.io',
-    domain: 'mailtrap.io',
+    address: 'smtp.mailtrap.io',
+    domain: 'smtp.mailtrap.io',
     port: '2525',
     authentication: :cram_md5,
     enable_starttls_auto: true


### PR DESCRIPTION
Mailtrap has switched SMTP domain from `mailtrap.io` to `smtp.mailtrap.io`