### PR TITLE
Updating loofah due to vulnerability detection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     kaminari-core (1.0.1)
     karo (2.5.2)
       thor (~> 0.19)
-    loofah (2.2.0)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -333,4 +333,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.14.6
+   1.16.1


### PR DESCRIPTION
actionpack -> rails-html-sanitizer -> loofah (~> 2.0)

Minor patch until they release a fix for Rails making sure they have a version of Loofah greater than (~> 2.2.1) in version 5.x.