### PR TITLE
Custom Simple Form Wrappers

### DIFF
--- a/app/assets/stylesheets/koi/components/_form.scss
+++ b/app/assets/stylesheets/koi/components/_form.scss
@@ -625,3 +625,17 @@ $file-thumbnail-width: 100px;
     @include flex-shrink(0);
   }
 }
+
+// =========================================================================
+// Missing wrapper warning
+// =========================================================================
+.form__needs-wrapper {
+  padding: $xxx-small-unit;
+  background: $error-background;
+  color: $error-color;
+
+  &:before {
+    display: block;
+    content: "Warning: This form field requires a wrapper attribute to avoid conflicts with front-end simple_form configuration."
+  }
+}

--- a/app/views/admins/passwords/edit.html.erb
+++ b/app/views/admins/passwords/edit.html.erb
@@ -3,12 +3,12 @@
 <%= simple_form_for(resource, :as => resource_name, :url => koi_engine.admin_password_path, :html => { method: :put, class: "form-vertical" }) do |f| %>
 
   <div class="bg-lightgrey">
-    <%= f.input :reset_password_token, :as => :hidden %>
+    <%= f.input :reset_password_token, wrapper: :koi, :as => :hidden %>
     <%= f.full_error :reset_password_token %>
 
     <div class="inputs">
-      <%= f.input :password, :label => "New password", required: true, autofocus: true, input_html: { class: "w-510" } %>
-      <%= f.input :password_confirmation, :label => "Confirm your new password", required: true, input_html: { class: "w-510" } %>
+      <%= f.input :password, wrapper: :koi, :label => "New password", required: true, autofocus: true, input_html: { class: "w-510" } %>
+      <%= f.input :password_confirmation, wrapper: :koi, :label => "Confirm your new password", required: true, input_html: { class: "w-510" } %>
     </div>
   </div>
   <div class="bg-mediumgrey">

--- a/app/views/admins/passwords/new.html.erb
+++ b/app/views/admins/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <%= simple_form_for(resource, :as => resource_name, :url => koi_engine.admin_password_path, :html => { method: :post, class: "form-vertical" }) do |f| %>
   <div class="bg-lightgrey">
     <div class="inputs">
-      <%= f.input :email,required: true, autofocus: true, input_html: { class: "form--medium" } %>
+      <%= f.input :email, wrapper: :koi, required: true, autofocus: true, input_html: { class: "form--medium" } %>
     </div>
   </div>
   <div class="bg-mediumgrey">

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -14,11 +14,11 @@
         <p class="error"><%= flash[:alert] %></p>
       <% end %>
 
-      <%= f.input :email, required: true, autofocus: true, input_html: { class: "form--medium" } %>
+      <%= f.input :email, wrapper: :koi, required: true, autofocus: true, input_html: { class: "form--medium" } %>
 
-      <%= f.input :password, required: true, input_html: { class: "form--medium", data: { password_reveal: "" } } %>
+      <%= f.input :password, wrapper: :koi, required: true, input_html: { class: "form--medium", data: { password_reveal: "" } } %>
 
-      <%= f.input :remember_me, as: :boolean, wrapper: :checkbox, wrapper_html: { class: "checkbox__single form--enhanced" }, label: "Keep me logged in on this computer" if devise_mapping.rememberable? %>
+      <%= f.input :remember_me, as: :boolean, wrapper: :koi_checkbox, wrapper_html: { class: "checkbox__single form--enhanced" }, label: "Keep me logged in on this computer" if devise_mapping.rememberable? %>
 
     </div>
   </div>

--- a/app/views/koi/admin_crud/_collection_settings.html.erb
+++ b/app/views/koi/admin_crud/_collection_settings.html.erb
@@ -2,9 +2,9 @@
 <% if @setting %>
   <%= render "koi/shared/flash_messages" %>
   <%= simple_form_for @setting, remote: true, html: { multipart: true, class: "koi-admin-crud-form" } do |f| %>
-    <%= f.input :url %>
-    <%= f.input :meta_title %>
-    <%= f.input :meta_description %>
+    <%= f.input :url, wrapper: :koi %>
+    <%= f.input :meta_title, wrapper: :koi %>
+    <%= f.input :meta_description, wrapper: :koi %>
     <%= f.submit %>
   <% end %>
 <% end %>

--- a/app/views/koi/admin_crud/_form_field_basic_file.html.erb
+++ b/app/views/koi/admin_crud/_form_field_basic_file.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :file, wrapper_html: wrapper_opts, input_html: input_opts } %>
+<%= f.input attr, as: :file, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts } %>

--- a/app/views/koi/admin_crud/_form_field_boolean.html.erb
+++ b/app/views/koi/admin_crud/_form_field_boolean.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :boolean, wrapper: :checkbox, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :boolean, wrapper: :koi_checkbox, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_check_boxes.html.erb
+++ b/app/views/koi/admin_crud/_form_field_check_boxes.html.erb
@@ -1,8 +1,8 @@
 <% data = resource_class.crud.find(:fields, attr, :data) %>
 <% if data.nil? %>
-  <%= f.input attr.to_sym, :as => :check_boxes, wrapper_html: wrapper_opts, input_html: input_opts %>
+  <%= f.input attr.to_sym, :as => :check_boxes, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>
 <% else %>
-  <%= f.input attr.to_sym, :as => :check_boxes, wrapper_html: wrapper_opts, collection: data %>
+  <%= f.input attr.to_sym, :as => :check_boxes, wrapper: :koi, wrapper_html: wrapper_opts, collection: data %>
 <% end %>
 
 <%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>

--- a/app/views/koi/admin_crud/_form_field_check_boxes_horizontal.html.erb
+++ b/app/views/koi/admin_crud/_form_field_check_boxes_horizontal.html.erb
@@ -4,9 +4,9 @@
 
 <% data = resource_class.crud.find(:fields, attr, :data) %>
 <% if data.nil? %>
-  <%= f.input attr.to_sym, :as => :check_boxes, wrapper_html: wrapper_opts, input_html: input_opts %>
+  <%= f.input attr.to_sym, :as => :check_boxes, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>
 <% else %>
-  <%= f.input attr.to_sym, :as => :check_boxes, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>
+  <%= f.input attr.to_sym, :as => :check_boxes, wrapper: :koi, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>
 <% end %>
 
 <%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>

--- a/app/views/koi/admin_crud/_form_field_code.html.erb
+++ b/app/views/koi/admin_crud/_form_field_code.html.erb
@@ -1,5 +1,5 @@
 <% editor_id, text_area_id = "#{attr}_code_editor", "#{attr}_text_area" %>
-<%= f.input attr, :input_html => { id: text_area_id }, wrapper_html: { class: "hidden" } %>
+<%= f.input attr, wrapper: :koi, :input_html => { id: text_area_id }, wrapper_html: { class: "hidden" } %>
 <%= content_tag :div, "", id: editor_id %>
 
 <script type="text/javascript">

--- a/app/views/koi/admin_crud/_form_field_colour.html.erb
+++ b/app/views/koi/admin_crud/_form_field_colour.html.erb
@@ -2,4 +2,4 @@
   input_opts[:data][:colourpicker] = ""
 %>
 
-<%= f.input attr, as: :string, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :string, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_date.html.erb
+++ b/app/views/koi/admin_crud/_form_field_date.html.erb
@@ -2,4 +2,4 @@
   input_opts[:class] += " datepicker input"
 %>
 
-<%= f.input attr, as: :string, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :string, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_datetime.html.erb
+++ b/app/views/koi/admin_crud/_form_field_datetime.html.erb
@@ -6,4 +6,4 @@
   input_opts[:class] += " datetime input datetimepicker"
 -%>
 
-<%= f.input attr, as: :string, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :string, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_default.html.erb
+++ b/app/views/koi/admin_crud/_form_field_default.html.erb
@@ -4,4 +4,4 @@
 
 <% input_opts.merge! disabled: true unless current_admin.send writable_method if writable_method %>
 
-<%= f.input attr, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_file.html.erb
+++ b/app/views/koi/admin_crud/_form_field_file.html.erb
@@ -46,7 +46,7 @@
           <label class="radio"><%= f.radio_button remove, false, checked: is_nil_or_new, id: html_id %> Upload a new <%= kind %></label>
         </div>
       </div>
-      <%= f.input_field attr, as: :file, label: false, onclick: "document.getElementById('#{html_id}').click()" %>
+      <%= f.input_field attr, as: :file, wrapper: :koi, label: false, onclick: "document.getElementById('#{html_id}').click()" %>
     </div>
   </div>
 

--- a/app/views/koi/admin_crud/_form_field_hidden.html.erb
+++ b/app/views/koi/admin_crud/_form_field_hidden.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :hidden %>
+<%= f.input attr, as: :hidden, wrapper: :koi %>

--- a/app/views/koi/admin_crud/_form_field_latlng.html.erb
+++ b/app/views/koi/admin_crud/_form_field_latlng.html.erb
@@ -5,7 +5,7 @@
   input_opts[:data].present? ? input_opts[:data].merge(latlng_data) : input_opts[:data] = latlng_data
 -%>
 
-<%= f.input attr, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>
 
 <div class="form--latlng" data-latlng-for="<%= attr -%>">
   <%= render layout: "koi/shared/inline_lightbox", locals: { title: "Find Location", inline_id: "#{attr}_lightbox", footer: capture { -%>

--- a/app/views/koi/admin_crud/_form_field_mask.html.erb
+++ b/app/views/koi/admin_crud/_form_field_mask.html.erb
@@ -4,4 +4,4 @@
   end
 -%>
 
-<%= f.input attr, as: :string, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :string, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_nice_tags.html.erb
+++ b/app/views/koi/admin_crud/_form_field_nice_tags.html.erb
@@ -1,5 +1,5 @@
 <%- id = "koi-#{ new_uuid }" -%>
-<%= f.input attr, as: :string, wrapper_html: { class: "form--medium" }, input_html: { id: id } %>
+<%= f.input attr, as: :string, wrapper: :koi, wrapper_html: { class: "form--medium" }, input_html: { id: id } %>
 
 <%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>
 

--- a/app/views/koi/admin_crud/_form_field_properties.html.erb
+++ b/app/views/koi/admin_crud/_form_field_properties.html.erb
@@ -1,2 +1,2 @@
-<%= f.input :presentation, as: :radio, collection: Image::PRESENTATION, wrapper_html: { class: "depth-2-inline" } %>
+<%= f.input :presentation, wrapper: :koi, as: :radio, collection: Image::PRESENTATION, wrapper_html: { class: "depth-2-inline" } %>
 

--- a/app/views/koi/admin_crud/_form_field_radio.html.erb
+++ b/app/views/koi/admin_crud/_form_field_radio.html.erb
@@ -1,6 +1,6 @@
 <% data = resource_class.crud.find(:fields, attr, :data) %>
 <% if data.nil? %>
-  <%= f.input attr.to_sym, :as => :radio, wrapper_html: wrapper_opts, input_html: input_opts %>
+  <%= f.input attr.to_sym, :as => :radio, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>
 <% else %>
-  <%= f.input attr.to_sym, :as => :radio, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>
+  <%= f.input attr.to_sym, :as => :radio, wrapper: :koi, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>
 <% end %>

--- a/app/views/koi/admin_crud/_form_field_radio_horizontal.html.erb
+++ b/app/views/koi/admin_crud/_form_field_radio_horizontal.html.erb
@@ -4,8 +4,8 @@
 
 <% data = resource_class.crud.find(:fields, attr, :data) %>
 <% if data.nil? %>
-  <%= f.input attr.to_sym, :as => :radio, wrapper_html: wrapper_opts, input_html: input_opts %>
+  <%= f.input attr.to_sym, :as => :radio, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>
 <% else %>
-  <%= f.input attr.to_sym, :as => :radio, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>
+  <%= f.input attr.to_sym, :as => :radio, wrapper: :koi, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>
 <% end %>
 

--- a/app/views/koi/admin_crud/_form_field_readonly.html.erb
+++ b/app/views/koi/admin_crud/_form_field_readonly.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :string, readonly: true, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :string, wrapper: :koi, readonly: true, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_rich_text.html.erb
+++ b/app/views/koi/admin_crud/_form_field_rich_text.html.erb
@@ -2,4 +2,4 @@
   input_opts[:class] += " wysiwyg source"
 %>
 
-<%= f.input attr, as: :text, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :text, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_select.html.erb
+++ b/app/views/koi/admin_crud/_form_field_select.html.erb
@@ -1,3 +1,3 @@
 <% data = f.object.class.crud.find(:fields, attr, :data) %>
 <% raise ArgumentError, "You must provide a 'data' hash value for '#{attr}' field type" if data.nil? %>
-<%= f.input attr.to_sym, :as => :select, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr.to_sym, :as => :select, wrapper: :koi, collection: data, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_string.html.erb
+++ b/app/views/koi/admin_crud/_form_field_string.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :string, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :string, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_tags.html.erb
+++ b/app/views/koi/admin_crud/_form_field_tags.html.erb
@@ -46,4 +46,4 @@
   </style>
 <% end %>
 
-<%= f.input attr, as: :string, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :string, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_uploader.html.erb
+++ b/app/views/koi/admin_crud/_form_field_uploader.html.erb
@@ -64,7 +64,7 @@
   #   existing_image = resource.send(crop_field).url
   # end
 
-  wrapper_class = attr
+  wrapper_class = attr.to_s
   wrapper_class += " error" unless f.error(id_field).blank?
 
 %>
@@ -95,10 +95,10 @@
     <div>
       
       <%# Hidden input field for #{attr}_crop (crop_string) %>
-      <%= f.input_field crop_field, as: :hidden, readonly: true if croppable -%>
+      <%= f.input_field crop_field, as: :hidden, wrapper: :koi, readonly: true if croppable -%>
 
       <%# Hidden input field to #{attr}_id (asset id) %>
-      <%= f.input_field id_field, as: :hidden -%>
+      <%= f.input_field id_field, as: :hidden, wrapper: :koi -%>
 
       <%# Dummy input field to track image uploading and passing options to javascript %>
       <input type="file" 

--- a/app/views/koi/admin_crud/_inline_fields.html.erb
+++ b/app/views/koi/admin_crud/_inline_fields.html.erb
@@ -1,6 +1,6 @@
 <%- nested_group_label = (f.object.respond_to?(:inline_titleize) && !f.object.inline_titleize.blank?) ? f.object.inline_titleize : singular_name_humanized %>
 <div class="nested-fields">
-  <%= f.input :ordinal, as: :hidden, wrapper_html: { class: "inline-ordinal-wrapper" }, input_html: { class: "inline-ordinal" } if is_orderable %>
+  <%= f.input :ordinal, as: :hidden, wrapper: :koi, wrapper_html: { class: "inline-ordinal-wrapper" }, input_html: { class: "inline-ordinal" } if is_orderable %>
   <div class="nested-fields__heading <%= "nested-fields-visible" unless f.object.errors.blank? %>" data-inline-nested-field-heading>
     <%- if is_orderable -%>
       <span class="drag-handler hidden">

--- a/app/views/koi/admin_crud/_resource_settings.html.erb
+++ b/app/views/koi/admin_crud/_resource_settings.html.erb
@@ -1,11 +1,11 @@
 <% if @setting %>
   <%= render "koi/shared/flash_messages" %>
   <%= simple_form_for @setting, remote: true, html: { multipart: true, class: "form-vertical" } do |f| %>
-    <%= f.input :set_type, as: :hidden %>
-    <%= f.input :set_id, as: :hidden %>
-    <%= f.input :url, as: :hidden %>
-    <%= f.input :meta_title %>
-    <%= f.input :meta_description %>
+    <%= f.input :set_type, wrapper: :koi, as: :hidden %>
+    <%= f.input :set_id, wrapper: :koi, as: :hidden %>
+    <%= f.input :url, wrapper: :koi, as: :hidden %>
+    <%= f.input :meta_title, wrapper: :koi %>
+    <%= f.input :meta_description, wrapper: :koi %>
     <ol class="unmarked-list floated-l-list spaced-r-1-list">
       <li>
         <%= content_tag :button, "Save", type: "submit", name: "commit", value: "Save", class: "btn btn-primary" %>

--- a/app/views/koi/admins/_form_field_roles.html.erb
+++ b/app/views/koi/admins/_form_field_roles.html.erb
@@ -1,4 +1,4 @@
 <% if current_admin.god? %>
-  <%= f.input :role, as: :select, collection: Admin::ROLES, input_html: { class: "form--medium" } %>
+  <%= f.input :role, as: :select, wrapper: :koi, collection: Admin::ROLES, input_html: { class: "form--medium" } %>
 <% end %>
 

--- a/app/views/koi/assets/_new.html.erb
+++ b/app/views/koi/assets/_new.html.erb
@@ -26,7 +26,7 @@
       </div>
 
       <div class="assets--upload--tags" style="display: none;">
-        <%= f.input :tag_list, as: :text, label: "#{ resource.new_record? ? "Add" : "Edit" } tags:", input_html: { class: "tagify input__tight" }, label_html: { class: "" } %>
+        <%= f.input :tag_list, as: :text, wrapper: :koi, label: "#{ resource.new_record? ? "Add" : "Edit" } tags:", input_html: { class: "tagify input__tight" }, label_html: { class: "" } %>
         <div>
           <div id="upload-button-upload" class="align-box-left">
             <%= f.button :button, "Upload", disabled: "disabled", class: "button" %>

--- a/app/views/koi/assets/edit.html.erb
+++ b/app/views/koi/assets/edit.html.erb
@@ -16,7 +16,7 @@
         <div class="inputs">
           <%= f.error_notification %>
 
-          <%= f.input :tag_list, as: :string, label: "#{ resource.new_record? ? "Add" : "Edit" } tags:", input_html: { class: "form--medium", value: tag_list.split(" ").join(","), data: { tag_input: "", tag_list: tag_list } } %>
+          <%= f.input :tag_list, as: :string, wrapper: :koi, label: "#{ resource.new_record? ? "Add" : "Edit" } tags:", input_html: { class: "form--medium", value: tag_list.split(" ").join(","), data: { tag_input: "", tag_list: tag_list } } %>
         </div>
 
         <div class="actions">

--- a/app/views/koi/crud/_form_field_date.html.erb
+++ b/app/views/koi/crud/_form_field_date.html.erb
@@ -5,4 +5,4 @@
     });
   </script>
 <% end %>
-<%= f.input attr, :as => :string, :input_html => { :class => "datepicker" } %>
+<%= f.input attr, :as => :string, wrapper: :koi, :input_html => { :class => "datepicker" } %>

--- a/app/views/koi/crud/_form_field_default.html.erb
+++ b/app/views/koi/crud/_form_field_default.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr %>
+<%= f.input attr, wrapper: :koi %>

--- a/app/views/koi/crud/_form_field_rich_text.html.erb
+++ b/app/views/koi/crud/_form_field_rich_text.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :text, input_html: { "koi-wysiwyg" => "", "data-class" => "wysiwyg" } %>
+<%= f.input attr, as: :text, wrapper: :koi, input_html: { "koi-wysiwyg" => "", "data-class" => "wysiwyg" } %>

--- a/app/views/koi/nav_items/_advanced_form_fields.html.erb
+++ b/app/views/koi/nav_items/_advanced_form_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="inputs">
   <%#= f.input :url %>
-  <%= f.input :admin_url %>
-  <%= f.input :key %>
-  <%= f.input :setting_prefix %>
-  <%= f.input :method, as: :string %>
+  <%= f.input :admin_url, wrapper: :koi %>
+  <%= f.input :key, wrapper: :koi %>
+  <%= f.input :setting_prefix, wrapper: :koi %>
+  <%= f.input :method, as: :string, wrapper: :koi %>
 </div>

--- a/app/views/koi/nav_items/_form_field_hidden.html.erb
+++ b/app/views/koi/nav_items/_form_field_hidden.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :hidden, input_html: { value: (resource.parent_id || params[:site_parent] || @site_parent) } %>
+<%= f.input attr, as: :hidden, wrapper: :koi, input_html: { value: (resource.parent_id || params[:site_parent] || @site_parent) } %>

--- a/app/views/koi/nav_items/_form_field_tree.html.erb
+++ b/app/views/koi/nav_items/_form_field_tree.html.erb
@@ -1,2 +1,2 @@
-<%= f.input attr, as: :select, collection: nested_set_options(NavItem, resource) {|i| "#{'-' * i.level} #{i.title}"} %>
+<%= f.input attr, as: :select, wrapper: :koi, collection: nested_set_options(NavItem, resource) {|i| "#{'-' * i.level} #{i.title}"} %>
 

--- a/app/views/koi/nav_items/_god_form_fields.html.erb
+++ b/app/views/koi/nav_items/_god_form_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="inputs">
-  <%= f.input :if, as: :string %>
-  <%= f.input :unless, as: :string %>
-  <%= f.input :highlights_on, as: :string %>
-  <%= f.input :content_block, as: :string %>
+  <%= f.input :if, as: :string, wrapper: :koi %>
+  <%= f.input :unless, as: :string, wrapper: :koi %>
+  <%= f.input :highlights_on, as: :string, wrapper: :koi %>
+  <%= f.input :content_block, as: :string, wrapper: :koi %>
 </div>

--- a/app/views/koi/settings/_field_boolean.html.erb
+++ b/app/views/koi/settings/_field_boolean.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :boolean, wrapper: :checkbox, label: label, hint: hint, wrapper_html: { class: "checkbox__single" } %>
+<%= f.input attr, as: :boolean, wrapper: :koi_checkbox, label: label, hint: hint, wrapper_html: { class: "checkbox__single" } %>

--- a/app/views/koi/settings/_field_boolean.html.erb
+++ b/app/views/koi/settings/_field_boolean.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :boolean, wrapper: :koi_checkbox, label: label, hint: hint, wrapper_html: { class: "checkbox__single" } %>
+<%= f.input attr, as: :boolean, wrapper: :koi_checkbox, label: label, hint: hint %>

--- a/app/views/koi/settings/_field_check_boxes.html.erb
+++ b/app/views/koi/settings/_field_check_boxes.html.erb
@@ -1,8 +1,8 @@
 <% data = object.data_source.call if object.data_source %>
 <% if data.nil? %>
-  <%= f.input :serialized_value, :as => :check_boxes, label: label, hint: hint %>
+  <%= f.input :serialized_value, :as => :check_boxes, wrapper: :koi, label: label, hint: hint %>
 <% else %>
-  <%= f.input :serialized_value, :as => :check_boxes, collection: data, label: label, hint: hint %>
+  <%= f.input :serialized_value, :as => :check_boxes, wrapper: :koi, collection: data, label: label, hint: hint %>
 <% end %>
 
 <%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>

--- a/app/views/koi/settings/_field_radio.html.erb
+++ b/app/views/koi/settings/_field_radio.html.erb
@@ -1,6 +1,6 @@
 <% data = object.data_source.call if object.data_source %>
 <% if data.nil? %>
-  <%= f.input attr.to_sym, :as => :radio_buttons, label: label, hint: hint %>
+  <%= f.input attr.to_sym, :as => :radio_buttons, wrapper: :koi, label: label, hint: hint %>
 <% else %>
-  <%= f.input attr.to_sym, :as => :radio_buttons, collection: data, label: label, hint: hint %>
+  <%= f.input attr.to_sym, :as => :radio_buttons, wrapper: :koi, collection: data, label: label, hint: hint %>
 <% end %>

--- a/app/views/koi/settings/_field_rich_text.html.erb
+++ b/app/views/koi/settings/_field_rich_text.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :text, label: label, hint: hint, input_html: { class: "wysiwyg source" } %>
+<%= f.input attr, as: :text, wrapper: :koi, label: label, hint: hint, input_html: { class: "wysiwyg source" } %>

--- a/app/views/koi/settings/_field_select.html.erb
+++ b/app/views/koi/settings/_field_select.html.erb
@@ -1,6 +1,6 @@
 <% data = object.data_source.call if object.data_source %>
 <% if data.nil? %>
-  <%= f.input attr, as: :string, label: label, hint: hint, input_html: { class: "form--medium" } %>
+  <%= f.input attr, as: :string, wrapper: :koi, label: label, hint: hint, input_html: { class: "form--medium" } %>
 <% else %>
-  <%= f.input attr.to_sym, :as => :select, collection: data, label: label, hint: hint, input_html: { class: "form--medium" } %>
+  <%= f.input attr.to_sym, :as => :select, wrapper: :koi, collection: data, label: label, hint: hint, input_html: { class: "form--medium" } %>
 <% end %>

--- a/app/views/koi/settings/_field_string.html.erb
+++ b/app/views/koi/settings/_field_string.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :string, label: label, hint: hint, input_html: { class: "form--medium" } %>
+<%= f.input attr, as: :string, wrapper: :koi, label: label, hint: hint, input_html: { class: "form--medium" } %>

--- a/app/views/koi/settings/_field_tags.html.erb
+++ b/app/views/koi/settings/_field_tags.html.erb
@@ -4,5 +4,5 @@
   tag_list.sort!
 %>
 
-<%= f.input :tag_list, as: :string, input_html: { class: "form--medium", data: { tag_input: "", tag_list: tag_list } }, label: label, hint: hint %>
+<%= f.input :tag_list, as: :string, wrapper: :koi, input_html: { class: "form--medium", data: { tag_input: "", tag_list: tag_list } }, label: label, hint: hint %>
 <%= render "koi/admin_crud/form_field_collection_errors", f: f, attr: attr %>

--- a/app/views/koi/settings/_field_text.html.erb
+++ b/app/views/koi/settings/_field_text.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :text, label: label, hint: hint, input_html: { class: "form--large" } %>
+<%= f.input attr, as: :text, wrapper: :koi, label: label, hint: hint, input_html: { class: "form--large" } %>

--- a/app/views/koi/translations/_form_field_boolean.html.erb
+++ b/app/views/koi/translations/_form_field_boolean.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :boolean, wrapper: :checkbox, wrapper_html: wrapper_opts, input_html: input_opts %>
+<%= f.input attr, as: :boolean, wrapper: :koi_checkbox, wrapper_html: wrapper_opts, input_html: input_opts %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,12 +1,14 @@
-# Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
 
+  # Default wrapper which DOES NOT render an input field
+  # This is to highlight that the form field NEEDS to have it's wrapper defined as :koi
   config.wrappers :koi_debug, tag: :div do |b|
     b.wrapper tag: :div, class: :controls do |ba|
       ba.use :label
     end
   end
 
+  # Generic input wrapper for all koi input fields
   config.wrappers :koi, tag: :div, class: 'control-group', error_class: :error, hint_class: :hint do |b|
     b.use :placeholder
     b.use :label
@@ -17,6 +19,7 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: :p, class: 'error-block' }
   end
 
+  # Specific checkbox wrapper to make boolean fields look nicer
   config.wrappers :koi_checkbox, tag: :div, class: 'control-group checkbox__single', error_class: :error, hint_class: :hint do |b|
     b.use :hint,  wrap_with: { tag: :p, class: 'hint-block' }
     b.wrapper tag: :div, class: :controls do |ba|
@@ -25,6 +28,8 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: :p, class: 'error-block' }
   end
 
+  # Baseline config updates that will get lost if custom simple_form initializer
+  # is present
   config.default_wrapper = :koi_debug
   config.boolean_style = :nested
   config.error_notification_tag = :div

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,57 +1,13 @@
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
-  # Wrappers are used by the form builder to generate a
-  # complete input. You can remove any component from the
-  # wrapper, change the order or even add your own to the
-  # stack. The options given below are used to wrap the
-  # whole input.
-  config.wrappers :default, class: :input,
-    hint_class: :field_with_hint, error_class: :field_with_errors do |b|
-    ## Extensions enabled by default
-    # Any of these extensions can be disabled for a
-    # given input by passing: `f.input EXTENSION_NAME => false`.
-    # You can make any of these extensions optional by
-    # renaming `b.use` to `b.optional`.
 
-    # Calculates placeholders automatically from I18n
-    # You can also pass a string as f.input placeholder: "Placeholder"
-    b.use :placeholder
-
-    ## Optional extensions
-    # They are disabled unless you pass `f.input EXTENSION_NAME => :lookup`
-    # to the input. If so, they will retrieve the values from the model
-    # if any exists. If you want to enable the lookup for any of those
-    # extensions by default, you can change `b.optional` to `b.use`.
-
-    # Calculates maxlength from length validations for string inputs
-    b.optional :maxlength
-
-    # Calculates pattern from format validations for string inputs
-    b.optional :pattern
-
-    # Calculates min and max from length validations for numeric inputs
-    b.optional :min_max
-
-    # Calculates readonly automatically from readonly attributes
-    b.optional :readonly
-
-    ## Inputs
-    b.use :label_input
-    b.use :hint,  wrap_with: { tag: :span, class: :hint }
-    b.use :error, wrap_with: { tag: :span, class: :error }
-  end
-
-  config.wrappers :inline, tag: :div, class: 'control-group', error_class: :error do |b|
-    b.use :placeholder
+  config.wrappers :koi_debug, tag: :div do |b|
     b.wrapper tag: :div, class: :controls do |ba|
-      ba.use :input
-      ba.use :label, wrap_with: { class: 'pad-l-1 space-l-1 control-label' }
+      ba.use :label
     end
-    b.use :error, wrap_with: { tag: :span, class: 'help-block pad-l-1 as-iblk' }
-    b.use :hint,  wrap_with: { tag: :p, class: 'help-block' }
   end
 
-  config.wrappers :bootstrap, tag: :div, class: 'control-group', error_class: :error do |b|
+  config.wrappers :koi, tag: :div, class: 'control-group', error_class: :error, hint_class: :hint do |b|
     b.use :placeholder
     b.use :label
     b.use :hint,  wrap_with: { tag: :p, class: 'hint-block' }
@@ -61,33 +17,7 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: :p, class: 'error-block' }
   end
 
-  config.wrappers :prepend, tag: :div, class: "control-group", error_class: :error do |b|
-    b.use :html5
-    b.use :placeholder
-    b.use :label
-    b.wrapper tag: :div, class: :controls do |input|
-      input.wrapper tag: :div, class: 'input-prepend' do |prepend|
-        prepend.use :input
-      end
-      input.use :hint,  wrap_with: { tag: :span, class: 'help-block' }
-      input.use :error, wrap_with: { tag: :span, class: 'help-block' }
-    end
-  end
-
-  config.wrappers :append, tag: :div, class: "control-group", error_class: :error do |b|
-    b.use :html5
-    b.use :placeholder
-    b.use :label
-    b.wrapper tag: :div, class: :controls do |input|
-      input.wrapper tag: :div, class: 'input-append' do |append|
-        append.use :input
-      end
-      input.use :hint,  wrap_with: { tag: :span, class: 'help-block' }
-      input.use :error, wrap_with: { tag: :span, class: 'help-block' }
-    end
-  end
-
-  config.wrappers :checkbox, tag: :div, class: 'control-group checkbox__single', error_class: :error do |b|
+  config.wrappers :koi_checkbox, tag: :div, class: 'control-group checkbox__single', error_class: :error, hint_class: :hint do |b|
     b.use :hint,  wrap_with: { tag: :p, class: 'hint-block' }
     b.wrapper tag: :div, class: :controls do |ba|
       ba.use :label_input
@@ -95,95 +25,11 @@ SimpleForm.setup do |config|
     b.use :error, wrap_with: { tag: :p, class: 'error-block' }
   end
 
-  # Wrappers for forms and inputs using the Twitter Bootstrap toolkit.
-  # Check the Bootstrap docs (http://twitter.github.com/bootstrap)
-  # to learn about the different styles for forms and inputs,
-  # buttons and other elements.
-  config.default_wrapper = :bootstrap
-
-  # Define the way to render check boxes / radio buttons with labels.
-  # Defaults to :nested for bootstrap config.
-  #   inline: input + label
-  #   nested: label > input
+  config.default_wrapper = :koi_debug
   config.boolean_style = :nested
-
-  # Default class for buttons
-  config.button_class = 'btn'
-
-  # Method used to tidy up errors.
-  # config.error_method = :first
-
-  # Default tag used for error notification helper.
   config.error_notification_tag = :div
-
-  # CSS class to add for error notification helper.
   config.error_notification_class = 'alert alert-error'
-
-  # ID to add for error notification helper.
-  # config.error_notification_id = nil
-
-  # Series of attempts to detect a default label method for collection.
-  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
-
-  # Series of attempts to detect a default value method for collection.
-  # config.collection_value_methods = [ :id, :to_s ]
-
-  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
-  # config.collection_wrapper_tag = nil
-
-  # You can define the class to use on all collection wrappers. Defaulting to none.
-  # config.collection_wrapper_class = nil
-
-  # You can wrap each item in a collection of radio/check boxes with a tag,
-  # defaulting to :span. Please note that when using :boolean_style = :nested,
-  # SimpleForm will force this option to be a label.
-  # config.item_wrapper_tag = :span
-
-  # You can define a class to use in all item wrappers. Defaulting to none.
-  # config.item_wrapper_class = nil
-
-  # How the label text should be generated altogether with the required text.
-  # config.label_text = lambda { |label, required| "#{required} #{label}" }
-
-  # You can define the class to use on all labels. Default is nil.
   config.label_class = 'control-label'
-
-  # You can define the class to use on all forms. Default is simple_form.
-  # config.form_class = :simple_form
-
-  # You can define which elements should obtain additional classes
-  # config.generate_additional_classes_for = [:wrapper, :label, :input]
-
-  # Whether attributes are required by default (or not). Default is true.
-  # config.required_by_default = true
-
-  # Tell browsers whether to use default HTML5 validations (novalidate option).
-  # Default is enabled.
   config.browser_validations = false
 
-  # Collection of methods to detect if a file type was given.
-  # config.file_methods = [ :mounted_as, :file?, :public_filename ]
-
-  # Custom mappings for input types. This should be a hash containing a regexp
-  # to match as key, and the input type that will be used when the field name
-  # matches the regexp as value.
-  # config.input_mappings = { /count/ => :integer }
-
-  # Default priority for time_zone inputs.
-  # config.time_zone_priority = nil
-
-  # Default priority for country inputs.
-  # config.country_priority = nil
-
-  # Default size for text inputs.
-  # config.default_input_size = 50
-
-  # When false, do not use translations for labels.
-  # config.translate_labels = true
-
-  # Automatically discover new inputs in Rails' autoload path.
-  # config.inputs_discovery = true
-
-  # Cache SimpleForm inputs discovery
-  # config.cache_discovery = !Rails.env.development?
 end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -3,15 +3,19 @@ SimpleForm.setup do |config|
   # Default wrapper which DOES NOT render an input field
   # This is to highlight that the form field NEEDS to have it's wrapper defined as :koi
   config.wrappers :koi_debug, tag: :div do |b|
-    b.wrapper tag: :div, class: :controls do |ba|
+    b.wrapper tag: :div, class: "form__needs-wrapper" do |ba|
       ba.use :label
     end
   end
 
   # Generic input wrapper for all koi input fields
-  config.wrappers :koi, tag: :div, class: 'control-group', error_class: :error, hint_class: :hint do |b|
+  config.wrappers :koi, tag: :div,
+    class: 'control-group',
+    error_class: :error,
+    hint_class: :hint do |b|
+
     b.use :placeholder
-    b.use :label
+    b.use :label, class: 'control-label'
     b.use :hint,  wrap_with: { tag: :p, class: 'hint-block' }
     b.wrapper tag: :div, class: :controls do |ba|
       ba.use :input
@@ -20,7 +24,13 @@ SimpleForm.setup do |config|
   end
 
   # Specific checkbox wrapper to make boolean fields look nicer
-  config.wrappers :koi_checkbox, tag: :div, class: 'control-group checkbox__single', error_class: :error, hint_class: :hint do |b|
+  config.wrappers :koi_checkbox, tag: :div, 
+    class: 'control-group checkbox__single',
+    error_class: :error,
+    hint_class: :hint,
+    boolean_label_class: "checkbox control-label",
+    boolean_style: :nested do |b|
+
     b.use :hint,  wrap_with: { tag: :p, class: 'hint-block' }
     b.wrapper tag: :div, class: :controls do |ba|
       ba.use :label_input
@@ -31,10 +41,7 @@ SimpleForm.setup do |config|
   # Baseline config updates that will get lost if custom simple_form initializer
   # is present
   config.default_wrapper = :koi_debug
-  config.boolean_style = :nested
   config.error_notification_tag = :div
-  config.error_notification_class = 'alert alert-error'
-  config.label_class = 'control-label'
-  config.browser_validations = false
+  config.error_notification_class = 'panel panel__error'
 
 end


### PR DESCRIPTION
RFC: https://github.com/katalyst/koi/issues/159
Something I've been meaning to do for a loooong time

### What are wrappers?

Simple Form has something called *wrappers*, these are the things that determine what markup gets used for form fields, it's what translates `<%= f.input :my_field %>` in to a bunch of divs and inputs.

### Why do we need custom ones?

The default simple_form wrappers worked well enough, but if we customised the wrappers due to design requirements on the front-end app, these customisations would bleed through to Koi. 

### What have I done?

I've created two custom wrappers, **koi**, and **koi_checkbox**.
**koi** is the generic input field used for 99% of the form fields, while **koi_checkbox** are used primarily for the `:boolean` form field types - single checkboxes.

I've cleared out the koi simple form config to the bare minimum and moved a lot of the config inline in to the wrappers themselves. This means you can customise simple form config as much as you like and it won't affect the koi fields.

I've gone through **every** form field I could find in Koi and updated the wrapper definitions to point to either `koi` or `koi_checkbox` where appropriate. 

There is a third wrapper, **koi_debug**, which I've set as the default wrapper for koi. What this does is set the default wrapper as a big ugly error message explaining that the developer needs to set a wrapper on their input field.

![screen shot 2018-10-18 at 10 46 36 am](https://user-images.githubusercontent.com/685024/47125759-cb410f00-d2cc-11e8-9ade-76b58c425571.png)

