### PR TITLE
Composable - Define fallback section name

### DIFF
--- a/app/models/concerns/composable.rb
+++ b/app/models/concerns/composable.rb
@@ -71,7 +71,7 @@ module Composable
         # isn't a new section
         if !current_composable_section && !datum["component_type"].eql?("section")
           current_composable_section = {
-            section_type: field_type_section_fallbacks[datum[:component_type]] || "body",
+            section_type: field_type_section_fallbacks[datum[:component_type]] || Koi::ComposableContent.fallback_section_type,
             section_data: []
           }
         end
@@ -81,7 +81,7 @@ module Composable
           composable_sections << current_composable_section if current_composable_section
           # create a new section from this datum
           current_composable_section = {
-            section_type: datum["section_type"] || "body",
+            section_type: datum["section_type"] || Koi::ComposableContent.fallback_section_type,
             section_data: []
           }
         # push datum to current page section

--- a/lib/koi/composable_components.rb
+++ b/lib/koi/composable_components.rb
@@ -29,6 +29,17 @@ module Koi
       @@components.values
     end
 
+    # Default fallacbk section type when no initial section type
+    # is used in composition
+    def self.fallback_section_type
+      @@fallback_section_type ||= "body"
+    end
+
+    # Method to change initial section type
+    def self.set_fallback_section_type(section_type)
+      @@fallback_section_type = section_type
+    end
+
     #
     # Register the default components we want in koi.
     # THese can be replaced by registering a component with the same name.

--- a/lib/koi/composable_components.rb
+++ b/lib/koi/composable_components.rb
@@ -36,7 +36,8 @@ module Koi
     end
 
     # Method to change initial section type
-    def self.set_fallback_section_type(section_type)
+    # Koi::ComposableContent.fallback_section_type = "my_custom_fallback"
+    def self.fallback_section_type=(section_type)
       @@fallback_section_type = section_type
     end
 


### PR DESCRIPTION
When creating a composition without using any sections, the composition on the front-end is wrapped in a default section, currently named "body".

If a developer overrides the section component to customise the list of sections and *doesn't* have a body section, the body section can get in the way.
For example, you might override the section list to be something like, `["large", "medium", "small"]`

This change provides a way to customise the name of the fallback section in the initailizer using:
```
Koi::ComposableContent.set_fallback_section_type "medium"
```