### PR TITLE
fixed count to be accurate for nested resources and for search results

### DIFF
--- a/app/views/koi/admin_crud/index.html.erb
+++ b/app/views/koi/admin_crud/index.html.erb
@@ -49,7 +49,7 @@
 
 <div class="listing--count">
   <div class="listing--count--items">
-    <span><%= pluralize(resource_class.count, "item") -%></span>
+    <span><%= pluralize(unpaginated_count, "item") -%></span>
     <% if is_searchable? %>
       <div class="listing--count--search">
         <%= render 'index_search' %>

--- a/lib/has_crud/has_crud/action_controller/admin/crud_methods.rb
+++ b/lib/has_crud/has_crud/action_controller/admin/crud_methods.rb
@@ -121,6 +121,10 @@ module HasCrud
             end
           end
 
+          def unpaginated_count
+            is_paginated? ? collection.total_count : collection.count
+          end
+
         end
 
       end


### PR DESCRIPTION
The record count above search currently shows the total number of records in the table, rather than the current result set. 

![image](https://user-images.githubusercontent.com/7999019/49974010-4fd7a300-ff87-11e8-92af-3e018979ef62.png)

This change should fix that. 