### PR TITLE
Managed asset field type

### DIFF
--- a/app/assets/javascripts/koi.js
+++ b/app/assets/javascripts/koi.js
@@ -58,6 +58,7 @@
 //= require koi/components/toggle
 //= require koi/components/form-latlng
 //= require koi/components/form-inline-nested
+//= require koi/components/form-managed-asset
 //= require koi/components/table
 //= require koi/components/styleguide
 

--- a/app/assets/javascripts/koi/components/form-managed-asset.js
+++ b/app/assets/javascripts/koi/components/form-managed-asset.js
@@ -38,8 +38,10 @@
         function updateThumbnail(url){
           if(url) {
             thumbnail.innerHTML = "<img src='" + getThumbnail(url) + "' />";
+            removeButton.parentNode.style.display = "block";
           } else {
             thumbnail.innerHTML = "<div className=\"composable--asset-field--empty-image\"></div>"
+            removeButton.parentNode.style.display = "none";
           }
         }
 

--- a/app/assets/javascripts/koi/components/form-managed-asset.js
+++ b/app/assets/javascripts/koi/components/form-managed-asset.js
@@ -40,7 +40,7 @@
             thumbnail.innerHTML = "<img src='" + getThumbnail(url) + "' />";
             removeButton.parentNode.style.display = "block";
           } else {
-            thumbnail.innerHTML = "<div className=\"composable--asset-field--empty-image\"></div>"
+            thumbnail.innerHTML = "<div class=\"composable--asset-field--empty-image\"></div>"
             removeButton.parentNode.style.display = "none";
           }
         }

--- a/app/assets/javascripts/koi/components/form-managed-asset.js
+++ b/app/assets/javascripts/koi/components/form-managed-asset.js
@@ -1,0 +1,83 @@
+/*jslint browser: true, indent: 2, todo: true, unparam: true */
+/*global jQuery,Ornament /*/
+
+(function (document, window, $) {
+
+  "use strict";
+
+  $(document).on("ornament:refresh", function () {
+
+    var assetManagers = document.querySelectorAll("[data-asset-manager-field]");
+    for(var i = 0; i < assetManagers.length; i++) {
+      (function(){
+        var assetManager = assetManagers[i];
+        var id = assetManager.getAttribute("data-asset-manager-field");
+        var browseButton = assetManager.querySelector("[data-asset-manager-browse]");
+        var removeButton = assetManager.querySelector("[data-asset-manager-remove]");
+        var hiddenField = assetManager.querySelector("#" + id);
+        var thumbnail = assetManager.querySelector("[data-asset-manager-thumbnail]");
+        var assetType = assetManager.getAttribute("data-asset-manager-type");
+        window["composableFieldImageCallback" + id] = finishedBrowsing;
+
+        // Get image placeholder
+        function getThumbnail(url, existing) {
+          if(!url) {
+            return false;
+          }
+          if(assetType === "document") {
+            return `/assets/koi/application/icon-file-pdf.png`;
+          }
+          if(existing) {
+            // this url will redirect to the correct url, regardless of the image's actual extension
+            return `/assets/${url}.jpg`;
+          }
+          return url;
+        }
+
+        // Update the thumbnail placeholder markup
+        function updateThumbnail(url){
+          if(url) {
+            thumbnail.innerHTML = "<img src='" + getThumbnail(url) + "' />";
+          } else {
+            thumbnail.innerHTML = "<div className=\"composable--asset-field--empty-image\"></div>"
+          }
+        }
+
+        // Open modal
+        function startBrowsing(e){
+          e.preventDefault();
+          const popupOptions = {
+            ...Ornament.popupOptions,
+            type: "iframe",
+            items: {
+              src: "/admin/" + assetType + "s/new?callbackFunction=composableFieldImageCallback" + id
+            }
+          };
+          $.magnificPopup.open(popupOptions);
+        }
+
+        // Closing modal when finishing
+        function finishedBrowsing(assetId, url) {
+          $.magnificPopup.close();
+          hiddenField.value = assetId;
+          updateThumbnail(url);
+        }
+
+        // Remove asset action
+        function clearField(e) {
+          e.preventDefault();
+          hiddenField.value = "";
+          updateThumbnail();
+        }
+
+        // button bindings
+        browseButton.removeEventListener("click", startBrowsing);
+        browseButton.addEventListener("click", startBrowsing);
+        removeButton.removeEventListener("click", clearField);
+        removeButton.addEventListener("click", clearField);
+      }());
+    }
+
+  });
+
+}(document, window, jQuery));

--- a/app/models/concerns/has_managed_assets.rb
+++ b/app/models/concerns/has_managed_assets.rb
@@ -3,16 +3,16 @@ module HasManagedAssets
 
   class_methods do
     def managed_image(attr, options={})
+      belongs_to :"#{attr}_association", foreign_key: :"#{attr}_asset_id", class_name: "Image"
       define_method attr do
-        id = send("#{attr}_asset_id")
-        Image.find_by(id: id).data if id
+        send("#{attr}_association").try(:data)
       end
     end
 
     def managed_document(attr, options={})
+      belongs_to :"#{attr}_association", foreign_key: :"#{attr}_asset_id", class_name: "Document"
       define_method attr do
-        id = send("#{attr}_asset_id")
-        Document.find_by(id: id).data if id
+        send("#{attr}_association").try(:data)
       end
     end
   end

--- a/app/models/concerns/has_managed_assets.rb
+++ b/app/models/concerns/has_managed_assets.rb
@@ -1,0 +1,20 @@
+module HasManagedAssets
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def managed_image(attr, options={})
+      define_method attr do
+        id = send("#{attr}_asset_id")
+        Image.find_by(id: id).data if id
+      end
+    end
+
+    def managed_document(attr, options={})
+      define_method attr do
+        id = send("#{attr}_asset_id")
+        Document.find_by(id: id).data if id
+      end
+    end
+  end
+
+end

--- a/app/views/koi/admin_crud/_form_field_managed_document.html.erb
+++ b/app/views/koi/admin_crud/_form_field_managed_document.html.erb
@@ -1,0 +1,1 @@
+<%= render "form_field_managed_image", asset_type: "document", f: f, attr: attr, wrapper_opts: wrapper_opts, input_opts: input_opts %>

--- a/app/views/koi/admin_crud/_form_field_managed_image.html.erb
+++ b/app/views/koi/admin_crud/_form_field_managed_image.html.erb
@@ -24,7 +24,7 @@
         </div>
         <div style="display: <%= value ? "block" : "none" %>">
           <button type="button" data-asset-manager-remove class="button__cancel"><%= remove_label %></button>
-          <%= link_to "View file", value.remote_url, class: "button", target: "_blank" if value.present?`` %>
+          <%= link_to "View file", value.remote_url, class: "button", target: "_blank" if value.present? %>
         </div>
       </div>
     </div>

--- a/app/views/koi/admin_crud/_form_field_managed_image.html.erb
+++ b/app/views/koi/admin_crud/_form_field_managed_image.html.erb
@@ -1,0 +1,31 @@
+<%
+  id = "koi-#{ new_uuid }"
+  value = f.object.send(attr)
+  attr_uid = "#{attr}_asset_id"
+  asset_type = asset_type || "image"
+  browse_label ||= "Browse for asset"
+  remove_label ||= "Remove asset"
+%>
+
+<%= f.input attr_uid, wrapper: :koi, wrapper_html: wrapper_opts, input_html: input_opts do %>
+  <div class="composable--asset-field" data-asset-manager-field="<%= id %>" data-asset-manager-type="<%= asset_type %>">
+    <div class="composable--asset-field--image" data-asset-manager-thumbnail>
+      <% if value %>
+        <%= attachment_image_tag(value) %>
+      <% else %>
+        <div className="composable--asset-field--empty-image"></div>
+      <% end %>
+    </div>
+    <div class="composable--asset-field--controls">
+      <%= f.input_field attr_uid, as: :hidden, id: id %>
+      <div class="button-group">
+        <div>
+          <button type="button" data-asset-manager-browse class="button__success"><%= browse_label %></button>
+        </div>
+        <div>
+          <button type="button" data-asset-manager-remove class="button__cancel"><%= remove_label %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/koi/admin_crud/_form_field_managed_image.html.erb
+++ b/app/views/koi/admin_crud/_form_field_managed_image.html.erb
@@ -13,7 +13,7 @@
       <% if value %>
         <%= attachment_image_tag(value) %>
       <% else %>
-        <div className="composable--asset-field--empty-image"></div>
+        <div class="composable--asset-field--empty-image"></div>
       <% end %>
     </div>
     <div class="composable--asset-field--controls">

--- a/app/views/koi/admin_crud/_form_field_managed_image.html.erb
+++ b/app/views/koi/admin_crud/_form_field_managed_image.html.erb
@@ -24,6 +24,7 @@
         </div>
         <div style="display: <%= value ? "block" : "none" %>">
           <button type="button" data-asset-manager-remove class="button__cancel"><%= remove_label %></button>
+          <%= link_to "View file", value.remote_url, class: "button", target: "_blank" if value.present?`` %>
         </div>
       </div>
     </div>

--- a/app/views/koi/admin_crud/_form_field_managed_image.html.erb
+++ b/app/views/koi/admin_crud/_form_field_managed_image.html.erb
@@ -22,7 +22,7 @@
         <div>
           <button type="button" data-asset-manager-browse class="button__success"><%= browse_label %></button>
         </div>
-        <div>
+        <div style="display: <%= value ? "block" : "none" %>">
           <button type="button" data-asset-manager-remove class="button__cancel"><%= remove_label %></button>
         </div>
       </div>

--- a/lib/has_crud/has_crud/active_record.rb
+++ b/lib/has_crud/has_crud/active_record.rb
@@ -60,6 +60,7 @@ module HasCrud
         setup_pagination
         setup_exportable
         setup_composable
+        setup_has_managed_assets
       end
 
       def setup_navigation
@@ -176,6 +177,12 @@ module HasCrud
       def setup_composable
         if self.options[:composable]
           send :include, Composable
+        end
+      end
+
+      def setup_has_managed_assets
+        if self.options[:has_managed_assets]
+          send :include, HasManagedAssets
         end
       end
 

--- a/test/dummy/app/models/kid_hero.rb
+++ b/test/dummy/app/models/kid_hero.rb
@@ -1,6 +1,5 @@
 class KidHero < SuperHero
-  include HasManagedAssets
-  has_crud
+  has_crud has_managed_assets: true
 
   managed_image :managed_image
   managed_document :managed_document

--- a/test/dummy/app/models/kid_hero.rb
+++ b/test/dummy/app/models/kid_hero.rb
@@ -1,16 +1,27 @@
 class KidHero < SuperHero
-
+  include HasManagedAssets
   has_crud
 
+  managed_image :managed_image
+  managed_document :managed_document
+
   crud.config do
-    fields gender: { type: :select, data: Gender }
+    fields gender:             { type: :select, data: Gender },
+           managed_image:      { type: :managed_image },
+           managed_document:   { type: :managed_document }
 
     index fields: [:name, :gender]
     form  fields: [:name, :gender]
 
     config :admin do
       index fields: [:name, :gender]
-      form  fields: [:name, :description, :gender]
+      form  fields: [
+        :name,
+        :description,
+        :gender,
+        :managed_image,
+        :managed_document,
+      ]
     end
   end
 

--- a/test/dummy/db/migrate/20181214012206_add_managed_assets_to_super_hero.rb
+++ b/test/dummy/db/migrate/20181214012206_add_managed_assets_to_super_hero.rb
@@ -1,0 +1,6 @@
+class AddManagedAssetsToSuperHero < ActiveRecord::Migration[5.1]
+  def change
+    add_column :super_heros, :managed_image_asset_id, :integer
+    add_column :super_heros, :managed_document_asset_id, :integer
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171021135838) do
+ActiveRecord::Schema.define(version: 20181214012206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,16 @@ ActiveRecord::Schema.define(version: 20171021135838) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["slug"], name: "index_categories_on_slug", unique: true
+  end
+
+  create_table "composables", id: :serial, force: :cascade do |t|
+    t.integer "composable_id"
+    t.string "composable_type"
+    t.jsonb "data"
+    t.string "slug"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["slug"], name: "index_composables_on_slug", unique: true
   end
 
   create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
@@ -147,7 +157,6 @@ ActiveRecord::Schema.define(version: 20171021135838) do
     t.string "colour"
     t.boolean "active", default: true
     t.integer "ordinal"
-    t.jsonb "composable_data"
     t.index ["slug"], name: "index_products_on_slug", unique: true
   end
 
@@ -197,15 +206,17 @@ ActiveRecord::Schema.define(version: 20171021135838) do
     t.integer "document_upload_id"
     t.string "document_upload_crop"
     t.string "last_location_seen"
+    t.integer "managed_image_asset_id"
+    t.integer "managed_document_asset_id"
     t.index ["slug"], name: "index_super_heros_on_slug", unique: true
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
-    t.string "taggable_type"
     t.integer "taggable_id"
-    t.string "tagger_type"
+    t.string "taggable_type"
     t.integer "tagger_id"
+    t.string "tagger_type"
     t.string "context", limit: 128
     t.datetime "created_at"
     t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true


### PR DESCRIPTION
New form field type for uploads via the asset manager.

```ruby
include HasManagedAssets

managed_image :banner_image # banner_image_asset_id
managed_document :case_study # case_study_asset_id

crud.config do
  fields banner_image: { type: :managed_image },
         case_study:   { type: :managed_document }
end
```

The `KidHero` model has been updated with a demo of a managed asset and a managed document.