### PR TITLE
Feature/asset manager updates for tnk 2019

### DIFF
--- a/app/assets/javascripts/koi/koi/assets.js
+++ b/app/assets/javascripts/koi/koi/assets.js
@@ -14,28 +14,31 @@ $ (function ()
 
       for (var key in params) if (params.hasOwnProperty (key)) try { params [key] = eval (params [key]) } catch (ex) {}
 
-      // work out whether it's ckeditor or some other callback function
-      var CKEditorFuncNumMatch = location.href.match (/[?&]CKEditorFuncNum=([^&]+)/i)
-      var callbackFunctionMatch = location.href.match (/[?&]callbackFunction=([^&]+)/i)
-
-      if(CKEditorFuncNumMatch) {
-        var CKEditorFuncNum = CKEditorFuncNumMatch[1]
-        window.opener.CKEDITOR.tools.callFunction (CKEditorFuncNum, url)
-      }
-      if(callbackFunctionMatch){
-        var callbackFunction = callbackFunctionMatch[1];
-        if(window.parent) {
-          window.parent[callbackFunction](assetId, url);
-        } else {
-          window.opener[callbackFunction](assetId, url)
-        }
-      }
-
-      window.close ()
+      Ornament.AssetManager.addToPage(assetId, url);
 
       return false
     });
 
   });
 
+  Ornament.AssetManager = Ornament.AssetManager || {};
+  Ornament.AssetManager.addToPage = function(assetId, url){
+      // work out whether it's ckeditor or some other callback function
+      var CKEditorFuncNumMatch = location.href.match (/[?&]CKEditorFuncNum=([^&]+)/i)
+      var callbackFunctionMatch = location.href.match (/[?&]callbackFunction=([^&]+)/i)
+
+      if(CKEditorFuncNumMatch) {
+          var CKEditorFuncNum = CKEditorFuncNumMatch[1]
+          window.opener.CKEDITOR.tools.callFunction (CKEditorFuncNum, url);
+          window.close();
+      }
+      if(callbackFunctionMatch){
+          var callbackFunction = callbackFunctionMatch[1];
+          if(window.parent) {
+              window.parent[callbackFunction](assetId, url);
+          } else {
+              window.opener[callbackFunction](assetId, url)
+          }
+      }
+  }
 })

--- a/app/assets/stylesheets/koi/components/_assets.scss
+++ b/app/assets/stylesheets/koi/components/_assets.scss
@@ -27,3 +27,9 @@
 .asset--options {
   margin-bottom: $xxx-small-unit;
 }
+
+.asset--uploader--actions a,
+.asset--uploader--actions button {
+  display: block;
+  margin-top: $xxxxx-small-unit;
+}

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -7,7 +7,7 @@ class Asset < ApplicationRecord
   scoped_search :on => [:data_name]
 
   scope :unassociated, -> { where("attributable_type IS NULL OR attributable_type = ''") }
-  scope :search_data,  -> query { where("data_name LIKE ?", "%#{query}%") }
+  scope :search_data,  -> query { where("data_name ILIKE ?", "%#{query}%") }
   scope :newest_first, -> { order(created_at: :desc) }
 
   acts_as_ordered_taggable

--- a/app/views/koi/assets/_listing.html.erb
+++ b/app/views/koi/assets/_listing.html.erb
@@ -12,6 +12,7 @@
     <%= hidden_field_tag :direction, params[:direction], id: "search_direction" %>
     <%= hidden_field_tag :sort     , params[:sort]     , id: "search_sort"      %>
     <%= hidden_field_tag :per      , params[:per]      , id: "search_per"       %>
+    <%= hidden_field_tag :callbackFunction, params[:callbackFunction], id: "callbackFunction" if params[:callbackFunction].present? %>
 
     <div class="panel--padding">
       <div class="inputs">

--- a/app/views/koi/assets/_new.html.erb
+++ b/app/views/koi/assets/_new.html.erb
@@ -60,6 +60,14 @@
           var $successMessage = thumbnail.find("[data-file-gallery-item-success]");
           var $assetActions = $("<div class='asset--uploader--actions' />");
           var $editLink = $("<a href='" + assetId + "?<%= request.query_parameters.to_query %>'>Edit <%= resource_class.name -%></a>");
+          <%- if params[:CKEditorFuncNum] || params[:callbackFunction]-%>
+            var $addToPageLink = $("<button type='button'>Add to page</button>");
+            $addToPageLink.on("click", function(){
+                // TODO: Think of a nicer way to show document URLs or just URLs in general eg. from controller
+                Ornament.AssetManager.addToPage(assetId, "/images/" + assetId + ".jpg");
+            });
+            $assetActions.append($addToPageLink);
+          <% end %>
           $assetActions.append($editLink);
           $successMessage.append($assetActions);
         });


### PR DESCRIPTION
Updates to asset manager, esp when used through CKEditor or `managed_image` fields:

- there's now an "Add to page" button after uploading an image in asset manager modal
- filtering in asset manager modal retains the knowledge it's in the modal (and now doesn't render the layout and will still provide "add to page" buttons")
- filtering uses case-insensitive search, so that a search for "buildings" will find images with "Buildings" in the name