### PR TITLE
Composable Content Groups

### DIFF
--- a/app/assets/stylesheets/koi/components/_composable.scss
+++ b/app/assets/stylesheets/koi/components/_composable.scss
@@ -11,6 +11,10 @@
   margin-bottom: $xxx-small-unit;
 }
 
+.composable-group .tabs--links {
+  margin-bottom: $xxx-small-unit;
+}
+
 // =========================================================================
 // Library of components
 // =========================================================================

--- a/app/assets/stylesheets/koi/components/_tabs.scss
+++ b/app/assets/stylesheets/koi/components/_tabs.scss
@@ -4,7 +4,8 @@ $tab-inactive-color: #ECF0F1;
 
 .tabs--links {
 
-  &.tabs--links__flush {
+  &.tabs--links__flush,
+  &.tabs--link__inpage {
     overflow: hidden;
   }
 
@@ -36,6 +37,7 @@ $tab-inactive-color: #ECF0F1;
   @include line-height-padding($button-height);
   @include transition(border-color .2s);
   @include border-radius($border-radius $border-radius 0 0);
+  @include disable-mouse-outline;
 
   .tabs--links__flush & {
     @include border-radius(0);

--- a/app/models/concerns/composable.rb
+++ b/app/models/concerns/composable.rb
@@ -15,6 +15,11 @@ module Composable
       composable_json.present?
     end
 
+    # Get all raw JSON data
+    # resource.composable_json => { main: [...] }
+    # Optionally get all raw JSON data for a specific group by
+    # passing in a group key
+    # resource.composable_json(:main) => [...]
     def composable_json(group=false)
       data = composable_data
       if data.present?
@@ -24,10 +29,13 @@ module Composable
       end
     end
 
+    # Get formatted composable content grouped in to sections for a specific group
+    # resource.composable_sections(:main)
     def composable_sections(group)
       Composable.format_composable_data(composable_data, group) if composable?
     end
 
+    # Same as composable_sections but includes drafts
     def composable_sections_with_drafts(group)
       Composable.format_composable_data(composable_data, group, include_drafts: true) if composable?
     end
@@ -74,6 +82,7 @@ module Composable
       data = JSON.parse(data)
     end
     if data.present?
+      # Select the group
       data = data[group.to_s]
       data.each_with_index do |datum,index|
         next if !include_drafts && datum["component_draft"].eql?(true)

--- a/app/views/koi/admin_crud/_form_field_composable.html.erb
+++ b/app/views/koi/admin_crud/_form_field_composable.html.erb
@@ -8,7 +8,7 @@
 
 <%= react_component("Composable", props: {
   composition: value,
-  composableTypes: f.object.class.composable_config,
+  config: f.object.class.composable_config,
   allComposableTypes: Koi::ComposableContent.components,
   showAdvancedSettings: Koi::ComposableContent.show_advanced_settings,
   icons: {

--- a/spec/dummy/app/frontend/javascripts/koi/Composable/Composable.jsx
+++ b/spec/dummy/app/frontend/javascripts/koi/Composable/Composable.jsx
@@ -275,7 +275,7 @@ export default class Composable extends React.Component {
   // undraft - draftComponent(10, "enable");
   draftComponent(componentIndex, visibility) {
     const composition = this.state.composition;
-    const component = composition[componentIndex];
+    const component = composition[this.state.group][componentIndex];
     if(!component) {
       console.warn("Unable to find component with index of " + componentIndex);
       return;

--- a/spec/dummy/app/frontend/javascripts/koi/Composable/Composable.jsx
+++ b/spec/dummy/app/frontend/javascripts/koi/Composable/Composable.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
-
-import ComposableLibrary from "./ComposableLibrary";
-import ComposableComposition from "./ComposableComposition";
+import ComposableGroupItem from './ComposableGroupItem';
 
 // a little function to help us with reordering the result
 const reorder = (list, startIndex, endIndex) => {
@@ -18,8 +15,9 @@ export default class Composable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      composition: this.props.composition || [],
+      composition: this.intialiseComposition(),
       error: false,
+      group: this.getInitialGroup(),
       debug: this.props.debug || localStorage.getItem("koiDebugComposable") || false,
     };
 
@@ -109,8 +107,43 @@ export default class Composable extends React.Component {
   }
 
   // =========================================================================
+  // Groups
+  // =========================================================================
+
+  // Switch between a different active group
+  setGroup = group => {
+    this.setState({
+      group,
+    });
+  }
+
+  // Simple helper to get the first group key
+  getInitialGroup = () => {
+    return Object.keys(this.props.config)[0];
+  }
+
+  // =========================================================================
   // Component data structures
   // =========================================================================
+
+  // Build out a nested JSON structure for all groups
+  // If there is a new group added in the crud config, this will ensure that
+  // it doesn't crash when trying to render the new group by initialising
+  // and empty array in the JSON named for that group
+  // It will merge in any existing data for groups that already exist
+  // => { group1: [], group2: [], group3: this.props.composition.group3 }
+  intialiseComposition = () => {
+    const structure = {};
+    const existing = this.props.composition;
+    Object.keys(this.props.config).forEach(key => {
+      if(existing && existing[key]) {
+        structure[key] = existing[key];
+      } else {
+        structure[key] = [];
+      }
+    });
+    return structure;
+  }
 
   /*
     Get the DataType template for a field type name
@@ -183,9 +216,9 @@ export default class Composable extends React.Component {
 
     // Push and setState
     if(atIndex !== false) {
-      composition.splice(atIndex, 0, newComponent);
+      composition[this.state.group].splice(atIndex, 0, newComponent);
     } else {
-      composition.push(newComponent);
+      composition[this.state.group].push(newComponent);
     }
     this.setState({
       composition,
@@ -197,8 +230,8 @@ export default class Composable extends React.Component {
   removeComponent(component) {
     if(confirm("Are you sure you want to remove this component?")) {
       let composition = this.state.composition;
-      let index = composition.indexOf(component);
-      composition.splice(index, 1);
+      let index = composition[this.state.group].indexOf(component);
+      composition[this.state.group].splice(index, 1);
       this.setState({
         composition,
       },() => {
@@ -212,7 +245,7 @@ export default class Composable extends React.Component {
   // show - collapseComponent(12, "show");
   collapseComponent(componentIndex, direction) {
     const composition = this.state.composition;
-    const component = composition[componentIndex];
+    const component = composition[this.state.group][componentIndex];
     if(!component) {
       console.warn("Unable to find component with index of " + componentIndex);
       return;
@@ -229,7 +262,7 @@ export default class Composable extends React.Component {
 
   collapseAllComponents(collapse) {
     const composition = this.state.composition;
-    composition.map(component => {
+    composition[this.state.group].map(component => {
       component.component_collapsed = collapse;
     });
     this.setState({
@@ -351,8 +384,9 @@ export default class Composable extends React.Component {
 
       // Reorder
       } else {
-        const composition = reorder(
-          this.state.composition,
+        const composition = { ...this.state.composition };
+        composition[this.state.group] = reorder(
+          composition[this.state.group],
           source.index,
           destination.index,
         );
@@ -390,9 +424,18 @@ export default class Composable extends React.Component {
       draftComponent: this.draftComponent,
       generateFieldAttributes: this.generateFieldAttributes,
       showAdvancedSettings: this.props.showAdvancedSettings,
+      group: this.state.group,
     };
 
-    const hasSection = this.state.composition.filter(component => component.component_type === "section").length > 0;
+    const groupHelpers = {
+      onDragStart: this.onDragStart,
+      onDragUpdate: this.onDragUpdate,
+      onDragEnd: this.onDragEnd,
+      collapseAllComponents: this.collapseAllComponents,
+    }
+
+    const groups = Object.keys(this.props.config);
+    const hasGroups = groups.length > 1;
 
     if(this.state.error) {
       return(
@@ -421,41 +464,36 @@ export default class Composable extends React.Component {
       );
     } else {
       return(
-        <DragDropContext
-          onDragStart={this.onDragStart}
-          onDragUpdate={this.onDragUpdate}
-          onDragEnd={this.onDragEnd}
-        >
-          <div className="composable--header">
-            <button type="button" onClick={e => this.collapseAllComponents(true)}>Collapse All</button> |
-            <button type="button" onClick={e => this.collapseAllComponents()}>Reveal All</button>
-          </div>
-          <div className={`composable ${hasSection ? "composable__with-sections" : ""}`}>
-            <div className="composable--composition" ref={el => this.$composition = el}>
-              <Droppable droppableId="composition" ignoreContainerClipping={true}>
-                {(compositionProvided, compositionSnapshot) => (
-                  <div ref={compositionProvided.innerRef} className={`${compositionSnapshot.isDraggingOver ? "composable--composition--drag-space" : ""}`}>
-                    <ComposableComposition
-                      helpers={composableHelpers}
-                    />
-                    {compositionProvided.placeholder}
-                  </div>
-                )}
-              </Droppable>
-              {this.state.debug &&
-                <div className="composable--fields--debug spacing-xxx-tight">
-                  <p><strong>Debug:</strong></p>
-                  <pre>data: {JSON.stringify(this.state.composition, null, 2)}</pre>
-                </div>
-              }
+        <div className="composable-group" ref={el => this.$composition = el}>
+          {hasGroups &&
+            <div className="tabs--links tabs--link__inpage">
+              <ul>
+                {groups.map(groupKey => (
+                  <li key={groupKey}>
+                    <button
+                      type="button"
+                      className={`tabs--link ${this.state.group === groupKey ? "active" : ""}`}
+                      onClick={e => this.setGroup(groupKey)}
+                    >{groupKey}</button>
+                  </li>
+                ))}
+              </ul>
             </div>
-            <ComposableLibrary
-              composableTypes={this.props.composableTypes}
-              helpers={composableHelpers}
-            />
-          </div>
+          }
+          <ComposableGroupItem
+            groupKey={this.state.group}
+            config={this.props.config}
+            helpers={composableHelpers}
+            groupHelpers={groupHelpers}
+          />
+          {this.state.debug &&
+            <div className="composable--fields--debug spacing-xxx-tight">
+              <p><strong>Debug:</strong></p>
+              <pre>data: {JSON.stringify(this.state.composition, null, 2)}</pre>
+            </div>
+          }
           <input type="hidden" name={this.props.attr} value={JSON.stringify(this.state.composition)} readOnly />
-        </DragDropContext>
+        </div>
       );
     }
   }

--- a/spec/dummy/app/frontend/javascripts/koi/Composable/ComposableComponent.jsx
+++ b/spec/dummy/app/frontend/javascripts/koi/Composable/ComposableComponent.jsx
@@ -45,8 +45,8 @@ export default class ComposableComponent extends React.Component {
   }
 
   onAdvancedFormChange(props) {
-    const composition = [ ...this.props.helpers.composition ];
-    composition[this.props.index].advanced = props.values;
+    const composition = { ...this.props.helpers.composition };
+    composition[this.props.helpers.group][this.props.index].advanced = props.values;
     this.props.helpers.replaceComposition(composition);
   }
 
@@ -55,8 +55,8 @@ export default class ComposableComponent extends React.Component {
   // =========================================================================
 
   onFormChange(props){
-    const composition = [ ...this.props.helpers.composition ];
-    composition[this.props.index].data = props.values;
+    const composition = { ...this.props.helpers.composition };
+    composition[this.props.helpers.group][this.props.index].data = props.values;
     this.props.helpers.replaceComposition(composition);
   }
 
@@ -207,7 +207,7 @@ export default class ComposableComponent extends React.Component {
                   <Form
                     onSubmit={e => false}
                     ref={el => this.advancedForm = el}
-                    initialValues={ this.props.helpers.composition[this.props.index].advanced }
+                    initialValues={ this.props.helpers.composition[this.props.helpers.group][this.props.index].advanced }
                     render={({ handleSubmit, form, values }) => (
                       <React.Fragment>
                         <FormSpy subscription={{ values: true }} onChange={this.onAdvancedFormChange} />
@@ -225,7 +225,7 @@ export default class ComposableComponent extends React.Component {
                   ...arrayMutators,
                 }}
                 ref={el => this.form = el}
-                initialValues={ this.props.helpers.composition[this.props.index].data }
+                initialValues={ this.props.helpers.composition[this.props.helpers.group][this.props.index].data }
                 validate={values => {
                   if(!template || !template.fields) {
                     return;

--- a/spec/dummy/app/frontend/javascripts/koi/Composable/ComposableComposition.jsx
+++ b/spec/dummy/app/frontend/javascripts/koi/Composable/ComposableComposition.jsx
@@ -10,14 +10,14 @@ export default class ComposableComposition extends React.Component {
   render() {
     const { helpers } = this.props;
 
-    if(helpers.composition.length === 0) {
+    if(helpers.composition[this.props.groupKey].length === 0) {
       return(
         <div className="composable--composition--empty">
           Drag a component here to start.
         </div>
       )
     } else {
-      return helpers.composition.map((component, index) => (
+      return helpers.composition[this.props.groupKey].map((component, index) => (
         <ComposableComponent
           key={component.id}
           component={component}

--- a/spec/dummy/app/frontend/javascripts/koi/Composable/ComposableGroupItem.jsx
+++ b/spec/dummy/app/frontend/javascripts/koi/Composable/ComposableGroupItem.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+
+import ComposableLibrary from "./ComposableLibrary";
+import ComposableComposition from "./ComposableComposition";
+
+export default class ComposableGroupItem extends React.Component {
+  render() {
+    const composition = this.props.helpers.composition[this.props.groupKey];
+    const hasSection = composition.length && composition.filter(component => component.component_type === "section").length > 0;
+
+    return(
+      <DragDropContext
+        onDragStart={this.props.groupHelpers.onDragStart}
+        onDragUpdate={this.props.groupHelpers.onDragUpdate}
+        onDragEnd={(result, provided) => this.props.groupHelpers.onDragEnd(result, provided, this.props.groupKey)}
+      >
+        <div className="composable--header">
+          <button type="button" onClick={e => this.props.groupHelpers.collapseAllComponents(true)}>Collapse All</button> |
+          <button type="button" onClick={e => this.props.groupHelpers.collapseAllComponents()}>Reveal All</button>
+        </div>
+        <div className={`composable ${hasSection ? "composable__with-sections" : ""}`}>
+          <div className="composable--composition">
+            <Droppable droppableId="composition" ignoreContainerClipping={true}>
+              {(compositionProvided, compositionSnapshot) => (
+                <div ref={compositionProvided.innerRef} className={`${compositionSnapshot.isDraggingOver ? "composable--composition--drag-space" : ""}`}>
+                  <ComposableComposition
+                    helpers={this.props.helpers}
+                    groupKey={this.props.groupKey}
+                  />
+                  {compositionProvided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </div>
+          <ComposableLibrary
+            composableTypes={this.props.config[this.props.groupKey]}
+            helpers={this.props.helpers}
+          />
+        </div>
+      </DragDropContext>
+    )
+  }
+}

--- a/spec/dummy/app/models/page.rb
+++ b/spec/dummy/app/models/page.rb
@@ -22,19 +22,24 @@ class Page < ApplicationRecord
       actions except: [:new]
       index   fields: [:id, :title]
       form    fields: [:title, :composable_data],
-              composable: [
-                :section,
-                :heading,
-                :text,
-                :rich_text,
-                :autocompletes,
-                :hero,
-                :hero_list,
-                :text_with_image,
-                :repeatable_thing,
-                :no_config,
-                :kitchen_sink
-              ]
+              composable: {
+                main: [
+                  :section,
+                  :heading,
+                  :text,
+                  :rich_text,
+                  :autocompletes,
+                  :hero,
+                  :hero_list,
+                  :text_with_image,
+                  :repeatable_thing,
+                  :no_config,
+                  :kitchen_sink
+                ],
+                sidebar: [
+                  :text,
+                ]
+              }
     end
   end
 

--- a/spec/dummy/app/views/pages/show.html.erb
+++ b/spec/dummy/app/views/pages/show.html.erb
@@ -10,11 +10,16 @@
   <%= JSON.pretty_generate @page.composable_json -%>
   </pre>
 
-  <h2 class="heading-two">Structured composable data (including drafts)</h2>
+  <h2 class="heading-two">Composable JSON for a group (:main)</h2>
   <pre>
-  <%= JSON.pretty_generate @page.composable_sections_with_drafts -%>
+  <%= JSON.pretty_generate @page.composable_json(:main) -%>
   </pre>
 
-  <h2 class="heading-two">Composable partials</h2>
-  <%= render "/shared/composables", sections: @page.composable_sections_with_drafts %>
+  <h2 class="heading-two">Structured composable data (including drafts) for group :main</h2>
+  <pre>
+  <%= JSON.pretty_generate @page.composable_sections_with_drafts(:main) -%>
+  </pre>
+
+  <h2 class="heading-two">Composable partials for :main</h2>
+  <%= render "/shared/composables", sections: @page.composable_sections_with_drafts(:main) %>
 <% end %>


### PR DESCRIPTION
### What problem does this solve?

Creating more than one composable content section on a single record / view.
Say you want a composable content in a sidebar and another in the main area of the page.
This isn't currently possible without hacks or abusing the sectioning component

### Current state

For reference, currently the composable config in the model looks like this:

```ruby
composable: [
  :component_1,
  :component_2,
  :component_3,
]
```

And the output of the composable content JSON is similar:

```js
components: [{
  component_type: "component_1",
  data: [{
    field1: value,
    field2: value,
  }]
}]
```

### Introducing groups

![Screen Shot 2019-05-15 at 4 06 19 pm](https://user-images.githubusercontent.com/685024/57753479-68610a80-772b-11e9-8af2-e0a4905993f6.png)

This change proposes a change to both the crud config and the output:

```ruby
composable: {
  main: [
    :component_1,
    :component_2,
    :component_3,
  ],
  sidebar: [
    :component_2,
    :component_4,
    :component_5,
  ]
}
```

```js
components: [{
  main: [{
    component_type: "component_1",
    data: [{
      field1: value,
      field2: value,
    }]
  }],
  sidebar: [{
    component_type: "component_5",
    data: [{
      field1: value,
    }]
  }]
}]
```

This change in structure will unfortunately mean it's a **breaking change**.

The code will assume all composable content will **always** have groups, so even if you aren't utilising groups, make sure you define a default group, eg. "main" or "default"
This will make the UI and implementation consistent and won't rely on hacks checking on whether groups exist or not

Once more than one group is detected, the UI of the composable content screen will update to show tabs to switch between content groups.
If you are only utilising a single group the UI will not change at all.

In your views you can now use `composable_json(:main)` and `composable_data(:sidebar)` to access your groups.
These flags also flow through to the existing `composable_sections(:main)` and `composable_sections_with_drafts(:main)`