### PR TITLE
TCW-202 - fixed managed image buttons in repeaters

### DIFF
--- a/app/assets/javascripts/koi/components/form-inline-nested.js
+++ b/app/assets/javascripts/koi/components/form-inline-nested.js
@@ -102,6 +102,7 @@
       // Init CKEditor if necessary
       initCkEditorOn(insertedItem);
       Ornament.C.FormHelpers.init();
+      Ornament.C.ManagedAsset.init();
       // Find the parent inline nested element and check if we 
       // need to update ordinals 
       var $inlineNested = insertedItem.closest("[data-inline-nested]");

--- a/app/assets/javascripts/koi/components/form-managed-asset.js
+++ b/app/assets/javascripts/koi/components/form-managed-asset.js
@@ -2,82 +2,90 @@
 /*global jQuery,Ornament /*/
 
 (function (document, window, $) {
-
   "use strict";
 
-  var ManagedAsset = Ornament.Components.ManagedAsset = {
-    init: function() {
-      var assetManagers = document.querySelectorAll("[data-asset-manager-field]");
-      for(var i = 0; i < assetManagers.length; i++) {
-        (function(){
-          var assetManager = assetManagers[i];
-          var id = assetManager.getAttribute("data-asset-manager-field");
-          var browseButton = assetManager.querySelector("[data-asset-manager-browse]");
-          var removeButton = assetManager.querySelector("[data-asset-manager-remove]");
-          var hiddenField = assetManager.querySelector("#" + id);
-          var thumbnail = assetManager.querySelector("[data-asset-manager-thumbnail]");
-          var assetType = assetManager.getAttribute("data-asset-manager-type");
-          window["composableFieldImageCallback" + id] = finishedBrowsing;
+  // Get image placeholder
+  function getThumbnail(type, url, existing) {
+    if (!url) {
+      return false;
+    }
+    if (type === "document") {
+      return "/assets/koi/application/icon-file-pdf.png";
+    }
+    if (existing) {
+      // this url will redirect to the correct url, regardless of the image's actual extension
+      return "/assets/" + url + ".jpg";
+    }
+    return url;
+  }
 
-          // Get image placeholder
-          function getThumbnail(url, existing) {
-            if(!url) {
-              return false;
-            }
-            if(assetType === "document") {
-              return "/assets/koi/application/icon-file-pdf.png";
-            }
-            if(existing) {
-              // this url will redirect to the correct url, regardless of the image's actual extension
-              return "/assets/" + url + ".jpg";
-            }
-            return url;
-          }
+  // Update the thumbnail placeholder markup
+  function updateThumbnail($this, url) {
+    var removeButton = $this.find("[data-asset-manager-remove]");
+    var thumbnail = $this.find("[data-asset-manager-thumbnail]");
+    var type = $this.data("asset-manager-type");
 
-          // Update the thumbnail placeholder markup
-          function updateThumbnail(url){
-            if(url) {
-              thumbnail.innerHTML = "<img src='" + getThumbnail(url) + "' />";
-              removeButton.parentNode.style.display = "block";
-            } else {
-              thumbnail.innerHTML = "<div class=\"composable--asset-field--empty-image\"></div>"
-              removeButton.parentNode.style.display = "none";
-            }
-          }
+    if (url) {
+      thumbnail.html("<img src='" + getThumbnail(type, url) + "' />");
+      removeButton.parent().css("display", "block");
+    } else {
+      thumbnail.html("<div class=\"composable--asset-field--empty-image\"></div>");
+      removeButton.parent().css("display", "none");
+    }
+  }
 
-          // Open modal
-          function startBrowsing(e){
-            e.preventDefault();
-            var popupOptions = $.extend({}, Ornament.popupOptions, {
-              type: "iframe",
-              items: {
-                src: "/admin/" + assetType + "s/new?callbackFunction=composableFieldImageCallback" + id
-              }
-            });
-            $.magnificPopup.open(popupOptions);
-          }
-
-          // Closing modal when finishing
-          function finishedBrowsing(assetId, url) {
-            $.magnificPopup.close();
-            hiddenField.value = assetId;
-            updateThumbnail(url);
-          }
-
-          // Remove asset action
-          function clearField(e) {
-            e.preventDefault();
-            hiddenField.value = "";
-            updateThumbnail();
-          }
-
-          // button bindings
-          browseButton.removeEventListener("click", startBrowsing);
-          browseButton.addEventListener("click", startBrowsing);
-          removeButton.removeEventListener("click", clearField);
-          removeButton.addEventListener("click", clearField);
-        }());
+  // Open modal
+  function startBrowsing(e) {
+    e.preventDefault();
+    var type = this.data("asset-manager-type");
+    var assetId = this.data("asset-manager-field");
+    var popupOptions = $.extend({}, Ornament.popupOptions, {
+      type: "iframe",
+      items: {
+        src: "/admin/" + type + "s/new?callbackFunction=composableFieldImageCallback" + assetId
       }
+    });
+    $.magnificPopup.open(popupOptions);
+  }
+
+  // Closing modal when finishing
+  function finishedBrowsing(assetId, url) {
+    $.magnificPopup.close();
+    var id = this.data("asset-manager-field");
+    this.find("#" + id).val(assetId);
+    updateThumbnail(this, url);
+  }
+
+  // Remove asset action
+  function clearField(e) {
+    e.preventDefault();
+    var id = this.data("asset-manager-field");
+    this.find("#" + id).val("");
+    updateThumbnail(this);
+  }
+
+  $.fn.manageAsset = function () {
+    if (this.data("asset-manager-field-loaded")) return;
+
+    this.data("asset-manager-field-loaded", true);
+
+    var id = this.data("asset-manager-field");
+    var assetType = this.data("asset-manager-type");
+
+    window["composableFieldImageCallback" + id] = finishedBrowsing.bind(this);
+
+    // button bindings
+    this.find("[data-asset-manager-browse]").on("click", startBrowsing.bind(this));
+    this.find("[data-asset-manager-remove]").on("click", clearField.bind(this));
+
+    return this;
+  };
+
+  var ManagedAsset = Ornament.Components.ManagedAsset = {
+    init: function () {
+      $("[data-asset-manager-field]").each(function () {
+        $(this).manageAsset()
+      });
     }
   };
 

--- a/app/assets/javascripts/koi/components/form-managed-asset.js
+++ b/app/assets/javascripts/koi/components/form-managed-asset.js
@@ -5,80 +5,84 @@
 
   "use strict";
 
-  $(document).on("ornament:refresh", function () {
+  var ManagedAsset = Ornament.Components.ManagedAsset = {
+    init: function() {
+      var assetManagers = document.querySelectorAll("[data-asset-manager-field]");
+      for(var i = 0; i < assetManagers.length; i++) {
+        (function(){
+          var assetManager = assetManagers[i];
+          var id = assetManager.getAttribute("data-asset-manager-field");
+          var browseButton = assetManager.querySelector("[data-asset-manager-browse]");
+          var removeButton = assetManager.querySelector("[data-asset-manager-remove]");
+          var hiddenField = assetManager.querySelector("#" + id);
+          var thumbnail = assetManager.querySelector("[data-asset-manager-thumbnail]");
+          var assetType = assetManager.getAttribute("data-asset-manager-type");
+          window["composableFieldImageCallback" + id] = finishedBrowsing;
 
-    var assetManagers = document.querySelectorAll("[data-asset-manager-field]");
-    for(var i = 0; i < assetManagers.length; i++) {
-      (function(){
-        var assetManager = assetManagers[i];
-        var id = assetManager.getAttribute("data-asset-manager-field");
-        var browseButton = assetManager.querySelector("[data-asset-manager-browse]");
-        var removeButton = assetManager.querySelector("[data-asset-manager-remove]");
-        var hiddenField = assetManager.querySelector("#" + id);
-        var thumbnail = assetManager.querySelector("[data-asset-manager-thumbnail]");
-        var assetType = assetManager.getAttribute("data-asset-manager-type");
-        window["composableFieldImageCallback" + id] = finishedBrowsing;
+          // Get image placeholder
+          function getThumbnail(url, existing) {
+            if(!url) {
+              return false;
+            }
+            if(assetType === "document") {
+              return "/assets/koi/application/icon-file-pdf.png";
+            }
+            if(existing) {
+              // this url will redirect to the correct url, regardless of the image's actual extension
+              return "/assets/" + url + ".jpg";
+            }
+            return url;
+          }
 
-        // Get image placeholder
-        function getThumbnail(url, existing) {
-          if(!url) {
-            return false;
+          // Update the thumbnail placeholder markup
+          function updateThumbnail(url){
+            if(url) {
+              thumbnail.innerHTML = "<img src='" + getThumbnail(url) + "' />";
+              removeButton.parentNode.style.display = "block";
+            } else {
+              thumbnail.innerHTML = "<div class=\"composable--asset-field--empty-image\"></div>"
+              removeButton.parentNode.style.display = "none";
+            }
           }
-          if(assetType === "document") {
-            return "/assets/koi/application/icon-file-pdf.png";
-          }
-          if(existing) {
-            // this url will redirect to the correct url, regardless of the image's actual extension
-            return "/assets/" + url + ".jpg";
-          }
-          return url;
-        }
 
-        // Update the thumbnail placeholder markup
-        function updateThumbnail(url){
-          if(url) {
-            thumbnail.innerHTML = "<img src='" + getThumbnail(url) + "' />";
-            removeButton.parentNode.style.display = "block";
-          } else {
-            thumbnail.innerHTML = "<div class=\"composable--asset-field--empty-image\"></div>"
-            removeButton.parentNode.style.display = "none";
-          }
-        }
-
-        // Open modal
-        function startBrowsing(e){
-          e.preventDefault();
-          var popupOptions = $.extend({}, Ornament.popupOptions, {
+          // Open modal
+          function startBrowsing(e){
+            e.preventDefault();
+            var popupOptions = $.extend({}, Ornament.popupOptions, {
               type: "iframe",
               items: {
-                  src: "/admin/" + assetType + "s/new?callbackFunction=composableFieldImageCallback" + id
+                src: "/admin/" + assetType + "s/new?callbackFunction=composableFieldImageCallback" + id
               }
-          });
-          $.magnificPopup.open(popupOptions);
-        }
+            });
+            $.magnificPopup.open(popupOptions);
+          }
 
-        // Closing modal when finishing
-        function finishedBrowsing(assetId, url) {
-          $.magnificPopup.close();
-          hiddenField.value = assetId;
-          updateThumbnail(url);
-        }
+          // Closing modal when finishing
+          function finishedBrowsing(assetId, url) {
+            $.magnificPopup.close();
+            hiddenField.value = assetId;
+            updateThumbnail(url);
+          }
 
-        // Remove asset action
-        function clearField(e) {
-          e.preventDefault();
-          hiddenField.value = "";
-          updateThumbnail();
-        }
+          // Remove asset action
+          function clearField(e) {
+            e.preventDefault();
+            hiddenField.value = "";
+            updateThumbnail();
+          }
 
-        // button bindings
-        browseButton.removeEventListener("click", startBrowsing);
-        browseButton.addEventListener("click", startBrowsing);
-        removeButton.removeEventListener("click", clearField);
-        removeButton.addEventListener("click", clearField);
-      }());
+          // button bindings
+          browseButton.removeEventListener("click", startBrowsing);
+          browseButton.addEventListener("click", startBrowsing);
+          removeButton.removeEventListener("click", clearField);
+          removeButton.addEventListener("click", clearField);
+        }());
+      }
     }
+  };
 
+  $(document).on("ornament:refresh", function () {
+    ManagedAsset.init();
   });
 
 }(document, window, jQuery));


### PR DESCRIPTION
the managed asset javascript was only binding on ornament:refresh, so when new inline
repeater items were created after clicking, say, "Add Banner", no event
handlers were being added to button so it was doing nothing

We'll need to do a release commit to bump the version after merging this, and upgrade Tonkin. 