### PR TITLE
Update index on translations

### DIFF
--- a/db/migrate/20201016042106_update_index_on_translations.rb
+++ b/db/migrate/20201016042106_update_index_on_translations.rb
@@ -1,0 +1,5 @@
+class UpdateIndexOnTranslations < ActiveRecord::Migration
+  def change
+    add_index :translations, [:prefix, :key]
+  end
+end


### PR DESCRIPTION
Queries in PFW are made using key and prefix, so the previous index was not being used due to ordering.
Updated index order to key, prefix, locale so that selects on key and (key,prefix) will use the index.
Added a separate index on locale in case other projects are using that.