### PR TITLE
Remove in-memory nav config cache

### DIFF
--- a/app/helpers/koi/navigation_helper.rb
+++ b/app/helpers/koi/navigation_helper.rb
@@ -28,13 +28,8 @@ module Koi::NavigationHelper
         NavItem.navigation(key, binding())
       end
     else
-      cached_nav_item(key)
+      NavItem.navigation(key, binding())
     end
-  end
-
-  def cached_nav_item(key)
-    @get_nav_items ||= {}
-    @get_nav_items[key] ||= NavItem.navigation(key, binding())
   end
 
   def cascaded_setting key


### PR DESCRIPTION
workaround for simple navigation bug. rendering nav causes nav options to be deleted, including :if lambda procs. AIT uses nav :if lambda procs to hide nav items depending on whether a user is logged in. AIT renders two navigations (desktop and mobile). The second nav to be rendered (mobile) does not include the :if lambda procs. So the mobile nav shows items it shouldn't.

This change removes the in-memory cache of navigation configuration, so options are regenerated each time navigation is rendered.