### PR TITLE
Expose nav item type to renderer

### DIFF
--- a/app/models/nav_item.rb
+++ b/app/models/nav_item.rb
@@ -80,6 +80,8 @@ class NavItem < ActiveRecord::Base
       hash[:method] = method
     end
 
+    hash[:"data-nav-item-type"] = self.class.name
+
     hash
   end
 
@@ -174,7 +176,7 @@ class NavItem < ActiveRecord::Base
         key:   nav_key,
         name:  title,
         url:   url,
-        items: children.collect { |c| c.to_hash(show_options) unless c.is_hidden }.compact
+        items: children.collect { |c| c.to_hash(show_options) unless c.is_hidden }.compact,
       }
     else
       hash = eval(content_block, @@binding)


### PR DESCRIPTION
adds 'data-nav-item-type' to the html output by simple navigation. This can be used by renderers to customise navigation based on the type of navigation items.

The motivation for this comes from the SATAC project, where we want to apply different styles to navigation items that have all direct descendants as 'Folder' navigation items.