### PR TITLE
Fix: Insert UrlRewrite middleware before Rack::Sendfile

### DIFF
--- a/lib/koi/engine.rb
+++ b/lib/koi/engine.rb
@@ -7,7 +7,7 @@ module Koi
 
     initializer "static assets" do |app|
       app.middleware.use ::ActionDispatch::Static, "#{root}/public"
-      app.middleware.use Koi::UrlRedirect
+      app.middleware.insert_before Rack::Sendfile, Koi::UrlRedirect
       app.config.assets.precompile += %w(
         koi.js
         koi/nav_items.js


### PR DESCRIPTION
 * This was present in previous versions of Koi but was removed during Rails6 upgrade