### PR TITLE
SAT-184: Use vanity urls for documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -19,11 +19,10 @@ class Document < Asset
     ext = File.extname(data_name).gsub('.', '')
     return Koi::KoiAsset::Document.icons[ext] if Koi::KoiAsset::Document.icons.has_key?(ext)
     return Koi::KoiAsset::Document.icons['img'] if Koi::KoiAsset::Image.extensions.include?(ext.to_sym)
-    return Koi::KoiAsset.unknown_image
+    Koi::KoiAsset.unknown_image
   end
 
   def url(*args)
-    data.url
+    "/#{ self.class.to_s.tableize }/#{ to_param }.#{ data.ext }"
   end
-
 end


### PR DESCRIPTION
Update for release/2.4 branch. Can probably be added to release/2.5 branch also.

Changed document url to be /documents/:id instead of linking directly to s3.
Matches behaviour of images.