### PR TITLE
Remove NavItem eval attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
  * Add github actions
  * Deprecate DateHelper methods: use Rails i18n instead.
  * Deprecate HtmlHelper methods: these do not appear to be used.
+ * Remove NavItem eval'd attributes: if, unless, highlights_on, content_block
+   * Editing of these inputs has been disabled since v2.2.0
 
 2.5.3 / 2021-07-13
 ==================

--- a/app/helpers/koi/navigation_helper.rb
+++ b/app/helpers/koi/navigation_helper.rb
@@ -27,10 +27,10 @@ module Koi
     def get_nav_items(key)
       if Koi::Caching.enabled
         Rails.cache.fetch(prefix_cache_key(key), expires_in: cache_expiry) do
-          NavItem.navigation(key, binding)
+          NavItem.navigation(key)
         end
       else
-        NavItem.navigation(key, binding)
+        NavItem.navigation(key)
       end
     end
 
@@ -65,31 +65,6 @@ module Koi
 
     def breadcrumb
       @breadcrumb ||= nav.self_and_descendants.compact.min_by(&:negative_highlight)
-    end
-
-    def nav(nav_item = nil)
-      navs_by_id[NavItem.for(nav_item).id]
-    end
-
-    def navs_by_id
-      @navs_by_id ||= navs_by_id!.each do |_id, nav|
-        if nav.parent_id
-          nav.parent = navs_by_id![nav.parent_id]
-          nav.parent.children << nav
-        end
-      end
-    end
-
-    def navs_by_id!
-      @navs_by_id ||= nav_items.map { |nav_item| [nav_item.id, nav_from(nav_item)] }.to_h
-    end
-
-    def nav_items
-      @nav_items ||= NavItem.order :lft
-    end
-
-    def nav_from(nav_item)
-      Navigator.new self, nav_item.to_hashish(binding) # , &filter
     end
 
     private

--- a/app/models/alias_nav_item.rb
+++ b/app/models/alias_nav_item.rb
@@ -6,14 +6,10 @@ class AliasNavItem < NavItem
   validates :title, :alias_id, :parent, presence: true
 
   crud.config do
-    fields parent_id:     { type: :hidden },
-           is_hidden:     { type: :boolean },
-           alias_id:      { type: :tree },
-           if:            { type: :code },
-           unless:        { type: :code },
-           method:        { type: :code },
-           highlights_on: { type: :code },
-           content_block: { type: :code }
+    fields parent_id: { type: :hidden },
+           is_hidden: { type: :boolean },
+           alias_id:  { type: :tree },
+           method:    { type: :code }
 
     config :admin do
       index fields: %i[id title url]

--- a/app/models/folder_nav_item.rb
+++ b/app/models/folder_nav_item.rb
@@ -10,11 +10,7 @@ class FolderNavItem < NavItem
            is_hidden:           { type: :boolean },
            link_to_first_child: { type: :boolean },
            alias_id:            { type: :tree },
-           if:                  { type: :code },
-           unless:              { type: :code },
-           method:              { type: :code },
-           highlights_on:       { type: :code },
-           content_block:       { type: :code }
+           method:              { type: :code }
 
     config :admin do
       index fields: %i[id title url]

--- a/app/models/module_nav_item.rb
+++ b/app/models/module_nav_item.rb
@@ -11,11 +11,7 @@ class ModuleNavItem < NavItem
            is_hidden:           { type: :boolean },
            link_to_first_child: { type: :boolean },
            alias_id:            { type: :tree },
-           if:                  { type: :code },
-           unless:              { type: :code },
-           method:              { type: :code },
-           highlights_on:       { type: :code },
-           content_block:       { type: :code }
+           method:              { type: :code }
 
     config :admin do
       index fields: %i[id title url]

--- a/app/models/resource_nav_item.rb
+++ b/app/models/resource_nav_item.rb
@@ -12,11 +12,7 @@ class ResourceNavItem < NavItem
            is_hidden:           { type: :boolean },
            link_to_first_child: { type: :boolean },
            alias_id:            { type: :tree },
-           if:                  { type: :code },
-           unless:              { type: :code },
-           method:              { type: :code },
-           highlights_on:       { type: :code },
-           content_block:       { type: :code }
+           method:              { type: :code }
 
     config :admin do
       index fields: %i[id title url]

--- a/app/models/root_nav_item.rb
+++ b/app/models/root_nav_item.rb
@@ -6,14 +6,10 @@ class RootNavItem < NavItem
   validates :title, presence: true
 
   crud.config do
-    fields parent_id:     { type: :hidden },
-           is_hidden:     { type: :boolean },
-           alias_id:      { type: :tree },
-           if:            { type: :code },
-           unless:        { type: :code },
-           method:        { type: :code },
-           highlights_on: { type: :code },
-           content_block: { type: :code }
+    fields parent_id: { type: :hidden },
+           is_hidden: { type: :boolean },
+           alias_id:  { type: :tree },
+           method:    { type: :code }
 
     config :admin do
       index fields: %i[id title url]

--- a/app/views/koi/nav_items/_advanced_form_fields.html.erb
+++ b/app/views/koi/nav_items/_advanced_form_fields.html.erb
@@ -1,5 +1,4 @@
 <div class="inputs">
-  <%#= f.input :url %>
   <%= f.input :admin_url %>
   <%= f.input :key %>
   <%= f.input :setting_prefix %>

--- a/app/views/koi/nav_items/_god_form_fields.html.erb
+++ b/app/views/koi/nav_items/_god_form_fields.html.erb
@@ -1,6 +1,0 @@
-<div class="inputs">
-  <%= f.input :if, as: :string %>
-  <%= f.input :unless, as: :string %>
-  <%= f.input :highlights_on, as: :string %>
-  <%= f.input :content_block, as: :string %>
-</div>

--- a/app/views/koi/nav_items/_modal_nav_item.html.erb
+++ b/app/views/koi/nav_items/_modal_nav_item.html.erb
@@ -23,9 +23,6 @@
           </li>
           <% if current_admin.god? %>
             <li><a href="#tab_advanced" class="tabs--link" data-tab="tab_advanced">Advanced</a></li>
-            <!--
-              <li><a href="#tab_god" class="tabs--link" data-tab="tab_god">God</a></li>
-            -->
           <% end %>
         </ul>
       </div>
@@ -34,15 +31,12 @@
     <div class="tabs--panes tabs--panes__flush">
       <div class="tabs--pane tabs--pane__active" id="tab_basic" data-tab-for="tab_basic">
         <div class="inputs">
-          <%= render "form_fields", { f: f } %>
+          <%= render "form_fields", f: f %>
         </div>
       </div>
       <% if current_admin.god? %>
         <div class="tabs--pane" id="tab_advanced" data-tab-for="tab_advanced">
-          <%= render "advanced_form_fields", { f: f } %>
-        </div>
-        <div class="tabs--pane" id="tab_god" data-tab-for="tab_god">
-          <%= render "god_form_fields", { f: f } %>
+          <%= render "advanced_form_fields", f: f %>
         </div>
       <% end %>
     </div>

--- a/app/views/layouts/koi/_navigation_item.html.erb
+++ b/app/views/layouts/koi/_navigation_item.html.erb
@@ -1,5 +1,5 @@
 <li class="<%= "selected" if request.path.eql?(item_url) -%>">
-  <%- if item_url.class.to_s.eql?("Hash") -%>
+  <%- if item_url.is_a?(Hash) -%>
     <a href="#"><%= item_name -%></a>
     <ul>
       <%- item_url.each do |child_name,child_url| -%>

--- a/db/migrate/20220330104437_remove_nav_item_eval_fields.rb
+++ b/db/migrate/20220330104437_remove_nav_item_eval_fields.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveNavItemEvalFields < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :nav_items, :if, :text
+    remove_column :nav_items, :unless, :text
+    remove_column :nav_items, :highlights_on, :text
+    remove_column :nav_items, :content_block, :text
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_317_225_250) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_30_115476) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20_210_317_225_250) do
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 40
     t.datetime "created_at"
-    t.index %w[slug sluggable_type], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", unique: true
     t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
@@ -77,11 +77,7 @@ ActiveRecord::Schema.define(version: 20_210_317_225_250) do
     t.integer "parent_id"
     t.integer "lft"
     t.integer "rgt"
-    t.text "if"
-    t.text "unless"
     t.text "method"
-    t.text "highlights_on"
-    t.text "content_block"
     t.integer "navigable_id"
     t.string "navigable_type"
     t.datetime "created_at"
@@ -189,10 +185,8 @@ ActiveRecord::Schema.define(version: 20_210_317_225_250) do
     t.integer "tagger_id"
     t.string "context", limit: 128
     t.datetime "created_at"
-    t.index %w[tag_id taggable_id taggable_type context tagger_id tagger_type], name:   "taggings_idx",
-                                                                                unique: true
-    t.index %w[taggable_id taggable_type context],
-            name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
   end
 
   create_table "tags", force: :cascade do |t|
@@ -219,8 +213,8 @@ ActiveRecord::Schema.define(version: 20_210_317_225_250) do
     t.string "file_name"
     t.text "serialized_value"
     t.string "group"
-    t.index %w[locale prefix key], name: "index_translations_on_locale_and_prefix_and_key", unique: true
-    t.index %w[prefix key], name: "index_translations_on_prefix_and_key"
+    t.index ["locale", "prefix", "key"], name: "index_translations_on_locale_and_prefix_and_key", unique: true
+    t.index ["prefix", "key"], name: "index_translations_on_prefix_and_key"
   end
 
   create_table "url_rewrites", force: :cascade do |t|


### PR DESCRIPTION
NavItem previously supported runtime eval for customising navigation
menus, but this was inherently un-cacheable and has not been possible
to edit these fields since v2.2.0 when caching was added (2016).

This commit adds a migration to remove the attributes and the runtime
eval implementation, which allows for a significant code cleanup.