### PR TITLE
Rubocop offense

### DIFF
--- a/spec/dummy/app/controllers/concerns/site_navigation.rb
+++ b/spec/dummy/app/controllers/concerns/site_navigation.rb
@@ -19,6 +19,6 @@ module SiteNavigation
   protected
 
   def set_site_navigation
-    @navigation_menus ||= Katalyst::Navigation::Menu.includes(:published_version).index_by(&:slug)
+    @navigation_menus ||= Katalyst::Navigation::Menu.includes(:published_version).index_by(&:slug) # rubocop:disable Naming/MemoizedInstanceVariableName
   end
 end

--- a/spec/dummy/lib/tasks/migrate.rake
+++ b/spec/dummy/lib/tasks/migrate.rake
@@ -35,7 +35,6 @@ class NavImporter
       add_link(child_item, depth + 1)
     end
   end
-
 end
 
 namespace :migrate do |args|


### PR DESCRIPTION
"Memoized variable @navigation_menus does not match method name set_navigation_menus. Use @set_navigation_menus instead."