### PR TITLE
FRIN23-107: Exclude turbo from handling links in asset listing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
-    digest (3.1.0)
     dragonfly (1.3.0)
       addressable (~> 2.3)
       multi_json (~> 1.0)
@@ -186,7 +185,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     katalyst-content (0.1.2)
-    katalyst-govuk-formbuilder (1.1.0)
+    katalyst-govuk-formbuilder (1.1.1)
       govuk_design_system_formbuilder
     katalyst-navigation (1.1.2)
     katalyst-tables (1.0.0)
@@ -202,20 +201,14 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.3)
     multi_json (1.15.0)
-    net-imap (0.2.3)
-      digest
+    net-imap (0.3.1)
       net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
+    net-pop (0.1.2)
       net-protocol
-      timeout
     net-protocol (0.1.3)
       timeout
-    net-smtp (0.3.1)
-      digest
+    net-smtp (0.3.2)
       net-protocol
-      timeout
     nio4r (2.5.8)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
@@ -268,7 +261,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.5.0)
+    regexp_parser (2.6.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -302,7 +295,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-katalyst (1.0.3)
+    rubocop-katalyst (1.0.4)
       rubocop
       rubocop-performance
       rubocop-rails
@@ -317,7 +310,7 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.13.1)
+    rubocop-rspec (2.13.2)
       rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     scoped_search (4.1.10)
@@ -337,14 +330,13 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.0)
+    sqlite3 (1.5.1)
       mini_portile2 (~> 2.8.0)
     stimulus-rails (1.1.0)
       railties (>= 6.0.0)
-    strscan (3.0.4)
     thor (1.2.1)
     timeout (0.3.0)
-    turbo-rails (1.1.1)
+    turbo-rails (1.3.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)

--- a/app/views/koi/assets/_listing.html.erb
+++ b/app/views/koi/assets/_listing.html.erb
@@ -62,7 +62,7 @@
     </div>
   </div>
 </div>
-<div class="table-container">
+<div class="table-container" data-turbo="false">
   <table class="table table-striped table-condensed txt-grey font-12px">
     <thead>
       <tr>

--- a/lib/has_navigation/has_navigation/has_navigation.rb
+++ b/lib/has_navigation/has_navigation/has_navigation.rb
@@ -65,11 +65,11 @@ module HasNavigation
   class << self
     def url_helpers
       @url_helpers ||= begin
-        # delayed initialization to ensure Rails application has loaded, Rails 5 has better options
-        UrlHelpers.include Rails.application.routes.url_helpers
-        UrlHelpers.include Rails.application.routes.mounted_helpers
-        UrlHelpers.new
-      end
+                         # delayed initialization to ensure Rails application has loaded, Rails 5 has better options
+                         UrlHelpers.include Rails.application.routes.url_helpers
+                         UrlHelpers.include Rails.application.routes.mounted_helpers
+                         UrlHelpers.new
+                       end
     end
   end
 


### PR DESCRIPTION
With turbo enabled, `koi/koi/assets.js` is not loading in the **assets -> show** page. This JS file is responsible for calling the `ckeditor` callback & for closing the popup.