### PR TITLE
Definition list updates

### DIFF
--- a/app/assets/stylesheets/koi/components/_item-table.scss
+++ b/app/assets/stylesheets/koi/components/_item-table.scss
@@ -17,7 +17,7 @@ $row-height: 48px !default;
 
 .item-table {
   display: grid;
-  grid-template-columns: 1fr 5fr;
+  grid-template-columns: auto 1fr;
   margin: 1rem 0;
   border-top: 1px solid var(--row-border-color);
 

--- a/app/helpers/koi/definition_list_helper.rb
+++ b/app/helpers/koi/definition_list_helper.rb
@@ -52,7 +52,7 @@ module Koi
       private
 
       def render?(**options)
-        !(options[:skip_blank] && attribute_value.blank?)
+        !(options[:skip_blank] && attribute_value.blank? && attribute_value != false)
       end
 
       def term_tag(**options)
@@ -69,7 +69,7 @@ module Koi
           when ActiveStorage::Attached::One
             tag.dd(attribute_value.attached? ? link_to(attribute_value.filename, url_for(attribute_value)) : "")
           else
-            tag.dd(attribute_value)
+            tag.dd(attribute_value.to_s)
           end
         end
       end

--- a/app/helpers/koi/definition_list_helper.rb
+++ b/app/helpers/koi/definition_list_helper.rb
@@ -75,8 +75,7 @@ module Koi
       end
 
       def label_for(**options)
-        options.dig(:label, :text) ||
-          t(attribute, scope: object.model_name.param_key.to_sym, default: attribute.to_s.humanize)
+        options.dig(:label, :text) || object.class.human_attribute_name(attribute)
       end
 
       def attribute_value


### PR DESCRIPTION
The existing code doesn't work when defining model attribute name overrides using rails conventions, e.g.

```yaml
en:
  activerecord:
    attributes:
      donation_target:
        stripe_product_id: Stripe product ID
```

this change will require the model to implement `ActiveModel::Translation` (ActiveRecord does this out of the box)