### PR TITLE
FRIN23-627: Refactor Admin UrlRewriteController

### DIFF
--- a/app/controllers/koi/url_rewrites_controller.rb
+++ b/app/controllers/koi/url_rewrites_controller.rb
@@ -1,7 +1,69 @@
 # frozen_string_literal: true
 
 module Koi
-  class UrlRewritesController < AdminCrudController
-    defaults route_prefix: ""
+  class UrlRewritesController < ApplicationController
+    before_action :set_url_rewrite, only: %i[show edit update destroy]
+
+    def index
+      @url_rewrites ||= UrlRewrite.all
+
+      @url_rewrites = @url_rewrites.admin_search(params[:search]) if params[:search]
+
+      sort, @url_rewrites = table_sort(@url_rewrites)
+      pagy, @url_rewrites = pagy(@url_rewrites)
+
+      @url_rewrites = @url_rewrites.alphabetical
+
+      render :index, locals: { url_rewrites: @url_rewrites, sort: sort, pagy: pagy }
+    end
+
+    def show
+      render :show, locals: { url_rewrite: @url_rewrite }
+    end
+
+    def new
+      @url_rewrite = UrlRewrite.new
+      render :new, locals: { url_rewrite: @url_rewrite }
+    end
+
+    def create
+      @url_rewrite = UrlRewrite.new(url_rewrite_params)
+
+      if @url_rewrite.save
+        redirect_to url_rewrite_path(@url_rewrite)
+      else
+        render :new, status: :unprocessable_entity, locals: { url_rewrite: @url_rewrite }
+      end
+    end
+
+    def edit
+      render :edit, locals: { url_rewrite: @url_rewrite }
+    end
+
+    def update
+      @url_rewrite.attributes = url_rewrite_params
+
+      if @url_rewrite.save
+        redirect_to url_rewrite_path(@url_rewrite)
+      else
+        render :edit, status: :unprocessable_entity, locals: { url_rewrite: @url_rewrite }
+      end
+    end
+
+    def destroy
+      @url_rewrite.destroy!
+
+      redirect_to url_rewrites_path
+    end
+
+    private
+
+    def url_rewrite_params
+      params.require(:url_rewrite).permit(:from, :to)
+    end
+
+    def set_url_rewrite
+      @url_rewrite = UrlRewrite.find(params[:id])
+    end
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -20,7 +20,7 @@ class AdminUser < ApplicationRecord
 
   scope :alphabetical, -> { order("LOWER(admins.last_name)", "LOWER(admins.first_name)") }
 
-  if AdminUser.connection_db_config.adapter == "postgresql" && require("pg_search")
+  if "PgSearch::Model".safe_constantize
     include PgSearch::Model
 
     pg_search_scope :admin_search, against: %i[email first_name last_name], using: { tsearch: { prefix: true } }

--- a/app/models/url_rewrite.rb
+++ b/app/models/url_rewrite.rb
@@ -1,22 +1,18 @@
 # frozen_string_literal: true
 
 class UrlRewrite < ApplicationRecord
-  has_crud
-
   validates :from, :to, presence: true
+  validates :from, format: { with: %r{\A/}, message: "should start with /" }
 
   scope :active, -> { where(active: true) }
+  scope :alphabetical, -> { order(from: :asc) }
 
   def to_s
     "#{from} -> #{to}"
   end
 
-  crud.config do
-    fields active: { type: :boolean }
-
-    config :admin do
-      index fields: %i[from to active]
-    end
+  scope :admin_search, ->(query) do
+    where(arel_table[:from].matches("%#{query}%").or(arel_table[:to].matches("%#{query}%")))
   end
 
   def self.redirect_path_for(path)

--- a/app/views/koi/url_rewrites/_form_fields.html.erb
+++ b/app/views/koi/url_rewrites/_form_fields.html.erb
@@ -1,0 +1,3 @@
+<%= form.govuk_text_field :from, label: { size: "s" }, hint: { text: "Should begin with /" } %>
+<%= form.govuk_text_field :to, label: { size: "s" } %>
+<%= form.govuk_check_box_field :active %>

--- a/app/views/koi/url_rewrites/edit.html.erb
+++ b/app/views/koi/url_rewrites/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Edit URL rewrite" %>
+<% content_for(:breadcrumbs) do %>
+  <%= link_to "URL rewrites", url_rewrites_path %> >
+  <%= link_to url_rewrite.from.delete_prefix("/"), url_rewrite_path(url_rewrite) %>
+<% end %>
+<% content_for :form_class, "govuk-forms" %>
+
+<%= form_with(model: url_rewrite, url: url_rewrite_path(url_rewrite)) do |form| %>
+  <%= render "form_fields", form: %>
+
+  <div class="govuk-button-group">
+    <%= form.admin_save %>
+    <%= form.admin_delete text: "Delete" %>
+  </div>
+<% end %>

--- a/app/views/koi/url_rewrites/index.html.erb
+++ b/app/views/koi/url_rewrites/index.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, "URL rewrites" %>
+
+<nav class="index-table-actions ornament-form">
+  <%= form_with url: request.path, method: :get, class: "form-search form-inline" do |form| %>
+    <div class="form-inline--input">
+      <%= form.search_field :search, placeholder: "Search", value: params[:search], class: "form-inline--input" %>
+    </div>
+    <%= form.submit "Go", class: "button button__primary form-inline--button" %>
+    <div class="form-inline--button">
+      <%= link_to "Reset", request.path, class: "button button--secondary" %>
+    </div>
+  <% end %>
+  <div class="item-actions">
+    <%= link_to "Add", new_url_rewrite_path, class: "button button--primary" %>
+  </div>
+</nav>
+
+<%= table_with collection: url_rewrites, sort: sort, class: "index-table" do |row, url_rewrite| %>
+  <%= row.cell :from do |cell| %>
+    <%= link_to cell.value, url_rewrite_path(url_rewrite) %>
+  <% end %>
+  <%= row.cell :to %>
+  <%= row.cell :active do |cell| %>
+    <%= cell.value ? "Yes" : "No" %>
+  <% end %>
+<% end %>
+
+<%== pagy_nav(pagy) %>

--- a/app/views/koi/url_rewrites/new.html.erb
+++ b/app/views/koi/url_rewrites/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "New URL rewrite" %>
+<% content_for(:breadcrumbs) do %>
+  <%= link_to "URL rewrites", url_rewrites_path %>
+<% end %>
+<% content_for :form_class, "govuk-forms" %>
+
+<%= form_with(model: url_rewrite, url: url_rewrites_path) do |form| %>
+  <%= render "form_fields", form: %>
+
+  <div class="govuk-button-group">
+    <%= form.admin_save %>
+  </div>
+<% end %>

--- a/app/views/koi/url_rewrites/show.html.erb
+++ b/app/views/koi/url_rewrites/show.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, url_rewrite.from %>
+<% content_for(:breadcrumbs) { link_to "URL rewrites", url_rewrites_path } %>
+<% content_for :title_actions do %>
+  <%= link_to "Edit", edit_url_rewrite_path(url_rewrite) %>
+<% end %>
+
+<h2 class="heading-four">Summary</h2>
+
+<%= definition_list(class: "item-table") do |builder| %>
+  <%= builder.items_with(model: url_rewrite, attributes: UrlRewrite.attribute_names.sort, skip_blank: true) %>
+<% end %>
+
+<div class="show--actions">
+  <%= button_to "Delete", url_rewrite_path(url_rewrite),
+                class:  "button button__secondary",
+                method: :delete,
+                form:   { data: { turbo_confirm: "Are you sure?" } } %>
+</div>

--- a/spec/factories/url_rewrites.rb
+++ b/spec/factories/url_rewrites.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :url_rewrite do
+    from { URI.parse(Faker::Internet.url).path }
+    to { Faker::Internet.url }
+    active { true }
+  end
+end

--- a/spec/models/url_rewrite_spec.rb
+++ b/spec/models/url_rewrite_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UrlRewrite, type: :model do
+  subject(:url_rewrite) { create :url_rewrite }
+
+  it { is_expected.to validate_presence_of(:from) }
+  it { is_expected.to validate_presence_of(:to) }
+  it { is_expected.to allow_values("/", "/path", "/path?query").for(:from) }
+  it { is_expected.not_to allow_values("", "path", "path?query", "https://example.com").for(:from) }
+
+  describe "#admin_search" do
+    subject { described_class.admin_search(url_rewrite.from) }
+
+    it { is_expected.to include(url_rewrite) }
+  end
+
+  describe "#redirect_path_for" do
+    subject { described_class.redirect_path_for(url_rewrite.from) }
+
+    it { is_expected.to eq(url_rewrite.to) }
+  end
+end

--- a/spec/requests/koi/url_rewrites_controller_spec.rb
+++ b/spec/requests/koi/url_rewrites_controller_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "support/requests/admin_examples"
+
+RSpec.describe Koi::UrlRewritesController, type: :request do
+  subject { action && response }
+
+  let(:admin) { create :admin }
+
+  include_context "with admin session"
+
+  describe "GET /admin/url_rewrites" do
+    let(:action) { get koi_engine.url_rewrites_path }
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to be_successful }
+
+    context "with search" do
+      let(:action) { get koi_engine.url_rewrites_path, params: { search: "dea" } }
+      let(:found) { create(:url_rewrite, from: "/deals") }
+
+      before do
+        found
+        create(:url_rewrite, from: "/offers")
+      end
+
+      it { is_expected.to be_successful }
+
+      it "filters" do
+        action
+        expect(assigns(:url_rewrites)).to contain_exactly(found)
+      end
+    end
+  end
+
+  describe "GET /admin/url_rewrites/new" do
+    let(:action) { get koi_engine.new_url_rewrite_path }
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to be_successful }
+  end
+
+  describe "POST /admin/url_rewrites" do
+    let(:action) { post koi_engine.url_rewrites_path, params: { url_rewrite: url_rewrite_params } }
+    let(:url_rewrite_params) { attributes_for :url_rewrite }
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to redirect_to(koi_engine.url_rewrite_path(assigns(:url_rewrite))) }
+
+    it "creates an url rewrite" do
+      expect { action }.to change(UrlRewrite, :count).by(1)
+    end
+  end
+
+  describe "GET /admin/url_rewrites/:id" do
+    let(:action) { get koi_engine.url_rewrite_path(url_rewrite) }
+    let(:url_rewrite) { create :url_rewrite }
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to be_successful }
+  end
+
+  describe "GET /admin/url_rewrites/:id/edit" do
+    let(:action) { get koi_engine.edit_url_rewrite_path(url_rewrite) }
+    let(:url_rewrite) { create :url_rewrite }
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to be_successful }
+  end
+
+  describe "PATCH /admin/url_rewrites/:id" do
+    let(:action) { patch koi_engine.url_rewrite_path(url_rewrite), params: { url_rewrite: url_rewrite_params } }
+    let(:url_rewrite_params) { { to: "/offers" } }
+    let(:url_rewrite) { create :url_rewrite, from: "/deals" }
+
+    before { url_rewrite }
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to redirect_to(koi_engine.url_rewrite_path(url_rewrite)) }
+
+    it "updates to" do
+      expect { action && url_rewrite.reload }.to(change(url_rewrite, :to).to("/offers"))
+    end
+
+    context "with invalid params" do
+      let(:url_rewrite_params) { { to: "" } }
+
+      it { is_expected.to be_unprocessable }
+    end
+  end
+
+  describe "DELETE /admin/url_rewrites/:id" do
+    let(:action) { delete koi_engine.url_rewrite_path(url_rewrite) }
+    let(:url_rewrite) { create :url_rewrite }
+
+    before { url_rewrite }
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to redirect_to(koi_engine.url_rewrites_path) }
+
+    it "removes an url rewrite" do
+      expect { action }.to change(UrlRewrite, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
- Adds `Archivable` concern from FRG to KOI - Not sure if it's a good idea
- Minor concern : Should we support paths without a leading backlash? Or add validation to start with backlash? 
```ruby
def self.redirect_path_for(path)
    not_archived.find_by(from: path).try(:to)
end
```
- Uses `delete_prefix` to remove leading backlash for breadcrumbs

FRG changes -> https://github.com/katalyst/frg/tree/refactor/FRIN23-627-admin-crud