### PR TITLE
Add close icon

### DIFF
--- a/app/views/koi/shared/icons/_close.html.erb
+++ b/app/views/koi/shared/icons/_close.html.erb
@@ -1,0 +1,8 @@
+<svg viewBox='0 0 18 18' width='<%= options[:width] %>' height='<%= options[:height] %>' class="icon-close">
+  <g id="Search-V2" sketch:type="MSPage">
+    <g id="Search-Results" transform="translate(-1074.000000, -111.000000)" sketch:type="MSArtboardGroup">
+      <path id="Imported-Layers" sketch:type="MSShapeGroup" fill="none" stroke="<%= options[:stroke] %>" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" d="
+        M1075.326,112L1091,127.675 M1090.674,112.073L1075,127.747"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
* This was removed in the commit `143874c23acbac93e6bd94c7a4f86abc9c0e7c98` but is referenced from flash_messages partial
* Sentry error ref from fringe: `https://adelaide-fringe.sentry.io/issues/3955840032/?environment=staging&project=5431524&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h`