### PR TITLE
Navigation prefix search

### DIFF
--- a/app/views/layouts/koi/application.html.erb
+++ b/app/views/layouts/koi/application.html.erb
@@ -24,7 +24,7 @@
 <body data-controller="keyboard"
       data-action="keyup->keyboard#event"
       data-keyboard-mapping-value="
-          Backslash->shortcut:search
+          Slash->shortcut:search
           KeyN->shortcut:create
           KeyG->shortcut:go
           Escape->shortcut:cancel


### PR DESCRIPTION
Improves navigation with prefix search, e.g. "vs" will match "View Site" but not "Previews". This is similar to the type of search used in JetBrains products that we're used to.

Also changes on-page search shortcut to use `/` instead of `\`.