### PR TITLE
Remove and replace `File.exists?` usage

### DIFF
--- a/lib/koi/release.rb
+++ b/lib/koi/release.rb
@@ -22,7 +22,7 @@ module Koi
 
     def read(file)
       return "HEAD" if Rails.env.development?
-      return "unknown" unless File.exists?(file)
+      return "unknown" unless File.exist?(file)
 
       File.read(file).strip
     end


### PR DESCRIPTION
* Ruby 3.2 has removed the support for `.exists?` and this can fixed to use `.exist?` instead