### PR TITLE
Fix - Content and Navigation engine namespaced to admin

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,12 +12,14 @@ Rails.application.routes.draw do
     resource :cache, only: %i[destroy]
     resource :dashboard, only: %i[show]
 
+    root to: redirect("admin/dashboard")
+  end
+
+  scope :admin do
     constraints ->(req) { req.session[:admin_user_id].present? } do
       mount Katalyst::Content::Engine, at: "content"
       mount Katalyst::Navigation::Engine, at: "navigation"
       mount Flipper::UI.app(Flipper) => "flipper" if Object.const_defined?("Flipper::UI")
     end
-
-    root to: redirect("admin/dashboard")
   end
 end

--- a/lib/koi/menu.rb
+++ b/lib/koi/menu.rb
@@ -17,9 +17,9 @@ module Koi
       builder = Builder.new
       builder.add_menu(title: "Priority") do |b|
         b.add_link(title: "View site", url: "/", target: "_blank")
-        b.add_link(title: "Dashboard", url: context.admin_dashboard_path)
+        b.add_link(title: "Dashboard", url: context.main_app.admin_dashboard_path)
         b.add_items(priority)
-        b.add_button(title: "Logout", url: context.admin_session_path, http_method: :delete)
+        b.add_button(title: "Logout", url: context.main_app.admin_session_path, http_method: :delete)
       end
       builder.add_menu(title: "Modules") do |b|
         b.add_items(modules)
@@ -28,14 +28,14 @@ module Koi
         b.add_items(advanced)
 
         if Object.const_defined?("Flipper::UI")
-          b.add_link(title:  "Flipper", url: context.admin_root_path.concat("flipper"),
+          b.add_link(title:  "Flipper", url: context.main_app.admin_root_path.concat("/flipper"),
                      target: "_blank")
         end
         if Object.const_defined?("Sidekiq::Web")
-          b.add_link(title:  "Sidekiq", url: context.admin_root_path.concat("sidekiq"),
+          b.add_link(title:  "Sidekiq", url: context.main_app.admin_root_path.concat("sidekiq"),
                      target: "_blank")
         end
-        b.add_button(title:       "Clear cache", url: context.admin_cache_path,
+        b.add_button(title:       "Clear cache", url: context.main_app.admin_cache_path,
                      http_method: :delete)
       end
       builder.render


### PR DESCRIPTION
mounting the engines causes the "engine_name" to be prefixed with the namespace. So `katalyst_content.root_path` would resolve to `admin_katalyst_content.root_path`. This causes issues as internally in the engines they refer to `katalyst_content` etc.

Moving the mount into a scope so it only affects the route not the helper generator