### PR TITLE
Fix: Missing translation for pagy gap

### DIFF
--- a/config/locales/pagy.en.yml
+++ b/config/locales/pagy.en.yml
@@ -3,3 +3,4 @@ en:
     nav:
       prev: "←&nbsp;&nbsp;Previous"
       next: "Next&nbsp;&nbsp;→"
+      gap: "&hellip;"


### PR DESCRIPTION
![Screenshot 2023-07-12 at 9 41 54 am](https://github.com/katalyst/koi/assets/100643476/47344d2f-f81c-4049-861b-c8601e472389)
