### PR TITLE
Fix: Explicitly set the database for the dummy app to sqlite3

### DIFF
--- a/lib/tasks/dummy.thor
+++ b/lib/tasks/dummy.thor
@@ -32,6 +32,7 @@ class Dummy < Thor
     run <<~SH
       cd spec && \
       rails new dummy \
+        --database sqlite3 \
         --skip-action-cable \
         --skip-action-mailer \
         --skip-action-mailbox \


### PR DESCRIPTION
If a developer has configuration for projects in (e.g.) a .railsrc file that sets a different database, the generator will fail as the adapter is not included in the template. We can remediate this issue by explicitly setting sqlite3 as the database when setting up the dummy application.