### PR TITLE
Summary component

### DIFF
--- a/app/assets/stylesheets/koi/components/_index.scss
+++ b/app/assets/stylesheets/koi/components/_index.scss
@@ -3,5 +3,5 @@
 @use "image-field";
 @use "index-actions";
 @use "index-table";
-@use "item-table";
 @use "pagy";
+@use "summary-list";

--- a/app/assets/stylesheets/koi/components/_summary-list.scss
+++ b/app/assets/stylesheets/koi/components/_summary-list.scss
@@ -4,13 +4,13 @@ $table-header-color: transparent !default;
 $row-border-color: $grey !default;
 $row-height: 48px !default;
 
-.item-table {
+.summary-list {
   --row-height: #{$row-height};
   --table-header-color: #{$table-header-color};
   --row-border-color: #{$row-border-color};
 }
 
-.item-table {
+.summary-list {
   display: grid;
   margin: 1rem 0;
   border-bottom: 1px solid var(--row-border-color);

--- a/app/components/koi/summary_list/base.rb
+++ b/app/components/koi/summary_list/base.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class Base < ViewComponent::Base
+      include Katalyst::HtmlAttributes
+
+      define_html_attribute_methods :term_attributes, default: {}
+      define_html_attribute_methods :description_attributes, default: {}
+
+      def initialize(model, attribute, label: nil, skip_blank: true)
+        super()
+
+        @model      = model
+        @attribute  = attribute
+        @label      = label
+        @skip_blank = skip_blank
+      end
+
+      def call
+        tag.dt(attribute_name, **term_attributes) + tag.dd(attribute_value, **description_attributes)
+      end
+
+      def render?
+        raw_value.present? || !@skip_blank
+      end
+
+      def attribute_name
+        @label&.dig(:text) || @model.class.human_attribute_name(@attribute)
+      end
+
+      def attribute_value
+        raw_value.to_s
+      end
+
+      def raw_value
+        @model.public_send(@attribute)
+      end
+
+      def inspect
+        "#<#{self.class.name} #{@attribute.inspect}>"
+      end
+    end
+  end
+end

--- a/app/components/koi/summary_list/boolean_component.rb
+++ b/app/components/koi/summary_list/boolean_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class BooleanComponent < Base
+      def render?
+        true
+      end
+
+      def attribute_value
+        raw_value ? "Yes" : "No"
+      end
+    end
+  end
+end

--- a/app/components/koi/summary_list/date_component.rb
+++ b/app/components/koi/summary_list/date_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class DateComponent < Base
+      def initialize(model, attribute, format: :admin, **options)
+        super(model, attribute, **options)
+
+        @format = format
+      end
+
+      def attribute_value
+        l(raw_value.to_date, format: @format) if raw_value.present?
+      end
+    end
+  end
+end

--- a/app/components/koi/summary_list/datetime_component.rb
+++ b/app/components/koi/summary_list/datetime_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class DatetimeComponent < Base
+      def initialize(model, attribute, format: :admin, **options)
+        super(model, attribute, **options)
+
+        @format = format
+      end
+
+      def attribute_value
+        l(raw_value.to_datetime, format: @format) if raw_value.present?
+      end
+    end
+  end
+end

--- a/app/components/koi/summary_list/item_component.rb
+++ b/app/components/koi/summary_list/item_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class ItemComponent < Base
+      def render?
+        !(@skip_blank && raw_value.blank? && raw_value != false)
+      end
+
+      def attribute_value
+        # preserve the legacy syntax where the value is passed to the block
+        if content?
+          return @__vc_original_view_context.capture do
+            @__vc_render_in_block.call(raw_value)
+          end
+        end
+
+        case raw_value
+        when Array
+          raw_value.join(", ")
+        when ActiveStorage::Attached::One
+          raw_value.attached? ? link_to(raw_value.filename, url_for(raw_value)) : ""
+        when Date, Time, DateTime, ActiveSupport::TimeWithZone
+          l(raw_value, format: :admin)
+        when TrueClass, FalseClass
+          raw_value ? "Yes" : "No"
+        else
+          raw_value.to_s
+        end
+      end
+    end
+  end
+end

--- a/app/components/koi/summary_list/number_component.rb
+++ b/app/components/koi/summary_list/number_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class NumberComponent < Base
+      def initialize(model, attribute, format: :admin, **options)
+        super(model, attribute, **options)
+
+        @format = format
+      end
+
+      def attribute_value
+        number_to_human(raw_value) if raw_value.present?
+      end
+
+      def default_description_attributes
+        { class: "number" }
+      end
+    end
+  end
+end

--- a/app/components/koi/summary_list/rich_text_component.rb
+++ b/app/components/koi/summary_list/rich_text_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class RichTextComponent < Base
+      def attribute_value
+        raw_value
+      end
+    end
+  end
+end

--- a/app/components/koi/summary_list/text_component.rb
+++ b/app/components/koi/summary_list/text_component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Koi
+  module SummaryList
+    class TextComponent < Base
+    end
+  end
+end

--- a/app/components/koi/summary_list_component.html.erb
+++ b/app/components/koi/summary_list_component.html.erb
@@ -1,0 +1,5 @@
+<%= tag.dl **html_attributes do %>
+  <% definitions.each do |definition| %>
+    <%= definition %>
+  <% end %>
+<% end %>

--- a/app/components/koi/summary_list_component.rb
+++ b/app/components/koi/summary_list_component.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Koi
+  class SummaryListComponent < ViewComponent::Base
+    include Katalyst::HtmlAttributes
+
+    renders_many :definitions, types: {
+      boolean:   SummaryList::BooleanComponent,
+      date:      SummaryList::DateComponent,
+      datetime:  SummaryList::DatetimeComponent,
+      number:    SummaryList::NumberComponent,
+      rich_text: SummaryList::RichTextComponent,
+      text:      SummaryList::TextComponent,
+
+      # @deprecated legacy interface
+      item:      SummaryList::ItemComponent,
+    }
+
+    def initialize(model: nil, skip_blank: true, **attributes)
+      super(**attributes)
+
+      @model      = model
+      @skip_blank = skip_blank
+    end
+
+    def boolean(attribute, label: nil)
+      with_definition_boolean(@model, attribute, label:)
+    end
+
+    def date(attribute, label: nil, format: :admin, skip_blank: @skip_blank)
+      with_definition_date(@model, attribute, label:, format:, skip_blank:)
+    end
+
+    def datetime(attribute, label: nil, format: :admin, skip_blank: @skip_blank)
+      with_definition_datetime(@model, attribute, label:, format:, skip_blank:)
+    end
+
+    def rich_text(attribute, label: nil, skip_blank: @skip_blank)
+      with_definition_rich_text(@model, attribute, label:, skip_blank:)
+    end
+
+    def number(attribute, label: nil, skip_blank: @skip_blank)
+      with_definition_number(@model, attribute, label:, skip_blank:)
+    end
+
+    def text(attribute, label: nil, skip_blank: @skip_blank)
+      with_definition_text(@model, attribute, label:, skip_blank:)
+    end
+
+    # @deprecated legacy interface
+    def item(model, attribute, label: nil, skip_blank: @skip_blank, &)
+      with_definition_item(model, attribute, label:, skip_blank:, &)
+    end
+
+    # @deprecated legacy interface
+    def items_with(model:, attributes:, **options)
+      attributes.each do |attribute|
+        item(model, attribute, **options)
+      end
+    end
+
+    def inspect
+      "#<#{self.class.name}>"
+    end
+
+    def default_html_attributes
+      { class: "summary-list" }
+    end
+  end
+end

--- a/app/helpers/koi/definition_list_helper.rb
+++ b/app/helpers/koi/definition_list_helper.rb
@@ -2,91 +2,9 @@
 
 module Koi
   module DefinitionListHelper
-    def definition_list(**options, &)
-      DefinitionListBuilder.new(self, options).render(&)
-    end
-  end
-
-  class DefinitionListBuilder
-    delegate_missing_to :@context
-
-    def initialize(context, options = {})
-      @context = context
-      @options = options
-    end
-
-    def render(&block)
-      tag.dl class: @options.delete(:class) do
-        concat(capture { yield self }) if block
-      end
-    end
-
-    def items_with(model:, attributes:, **options)
-      capture do
-        attributes.each do |attribute|
-          concat item(model, attribute, **options)
-        end
-      end
-    end
-
-    def item(object, attribute, **options, &)
-      Definition.new(@context, object, attribute, **@options, **options).render(&)
-    end
-
-    class Definition
-      attr_reader :object, :attribute, :options
-
-      delegate_missing_to :@context
-
-      def initialize(context, object, attribute, options = {})
-        @context   = context
-        @object    = object
-        @attribute = attribute
-        @options   = options
-      end
-
-      def render(&)
-        return unless render?
-
-        term_tag + definition_tag(&)
-      end
-
-      private
-
-      def render?
-        !(options.fetch(:skip_blank, true) && attribute_value.blank? && attribute_value != false)
-      end
-
-      def term_tag
-        tag.dt(label)
-      end
-
-      def definition_tag(&block)
-        if block
-          tag.dd { yield attribute_value }
-        else
-          case attribute_value
-          when Array
-            tag.dd(attribute_value.join(", "))
-          when ActiveStorage::Attached::One
-            tag.dd(attribute_value.attached? ? link_to(attribute_value.filename, url_for(attribute_value)) : "")
-          when Date, Time, DateTime, ActiveSupport::TimeWithZone
-            tag.dd(l(attribute_value, format: :admin))
-          when TrueClass, FalseClass
-            tag.dd(attribute_value ? "Yes" : "No")
-          else
-            tag.dd(attribute_value.to_s)
-          end
-        end
-      end
-
-      def label
-        options.dig(:label, :text) || object.class.human_attribute_name(attribute)
-      end
-
-      def attribute_value
-        @attribute_value ||= object.public_send(attribute)
-      end
+    # @deprecated This method is deprecated and will be removed in Koi 5.
+    def definition_list(**options, &block)
+      render Koi::SummaryListComponent.new(**options), &block
     end
   end
 end

--- a/lib/generators/koi/admin_views/admin_views_generator.rb
+++ b/lib/generators/koi/admin_views/admin_views_generator.rb
@@ -47,6 +47,25 @@ module Koi
       end
     end
 
+    def summary_attribute_for(attribute)
+      case attribute.type
+      when :string
+        %(<% dl.text :#{attribute.name} %>)
+      when :integer
+        %(<% dl.number :#{attribute.name} %>)
+      when :boolean
+        %(<% dl.boolean :#{attribute.name} %>)
+      when :date
+        %(<% dl.date :#{attribute.name} %>)
+      when :datetime
+        %(<% dl.datetime :#{attribute.name} %>)
+      when :rich_text
+        %(<% dl.rich_text :#{attribute.name} %>)
+      else
+        %(<% dl.text :#{attribute.name} %>)
+      end
+    end
+
     def index_attributes
       attributes.select { |attribute| attribute.type == :string }.take(3)
     end

--- a/lib/generators/koi/admin_views/templates/show.html.erb.tt
+++ b/lib/generators/koi/admin_views/templates/show.html.erb.tt
@@ -4,9 +4,9 @@
 
 <h2>Summary</h2>
 
-<%%= definition_list(class: "item-table") do |builder| %>
+<%%= render Koi::SummaryListComponent.new(model: <%= singular_name %>) do |dl| %>
 <%- attributes.each do |attribute| -%>
-  <%%= builder.item <%= singular_name %>, :<%= attribute.name %> %>
+  <%= summary_attribute_for attribute %>
 <%- end -%>
 <%% end %>
 

--- a/spec/components/koi/summary_list/boolean_component_spec.rb
+++ b/spec/components/koi/summary_list/boolean_component_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Koi::SummaryList::BooleanComponent do
+  subject(:component) { Koi::SummaryListComponent.new(model:) }
+
+  let(:model) { create(:post) }
+
+  describe "#boolean" do
+    let(:render) do
+      render_inline(component) do |dl|
+        dl.boolean(:active)
+      end
+    end
+
+    before { render }
+
+    it { expect(page).to have_css("dt", text: "Active") }
+    it { expect(page).to have_css("dt + dd", text: "Yes") }
+
+    context "with label" do
+      let(:render) do
+        render_inline(component) do |dl|
+          dl.boolean(:active, label: { text: "Custom" })
+        end
+      end
+
+      it { expect(page).to have_css("dt", text: "Custom") }
+    end
+
+    context "with false" do
+      let(:model) { create(:post, active: false) }
+
+      it { expect(page).to have_css("dt", text: "Active") }
+      it { expect(page).to have_css("dt + dd", text: "No") }
+    end
+  end
+end

--- a/spec/components/koi/summary_list/date_component_spec.rb
+++ b/spec/components/koi/summary_list/date_component_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Koi::SummaryList::DateComponent do
+  subject(:component) { Koi::SummaryListComponent.new(model:) }
+
+  let(:model) { create(:post) }
+
+  describe "#date" do
+    let(:render) do
+      render_inline(component) do |dl|
+        dl.date(:published_on)
+      end
+    end
+
+    before { render }
+
+    it { expect(page).to have_css("dt", text: "Published on") }
+    it { expect(page).to have_css("dt + dd", text: I18n.l(model.published_on, format: :admin)) }
+
+    context "with format" do
+      let(:render) do
+        render_inline(component) do |dl|
+          dl.date(:published_on, format: :short)
+        end
+      end
+
+      it { expect(page).to have_css("dt + dd", text: I18n.l(model.published_on, format: :short)) }
+    end
+
+    context "with blank" do
+      let(:model) { create(:post, published_on: nil) }
+
+      it { expect(page).not_to have_css("dt") }
+    end
+
+    context "with blank and skip_blank: false" do
+      subject(:component) { Koi::SummaryListComponent.new(model:, skip_blank: false) }
+
+      let(:model) { create(:post, published_on: nil) }
+
+      it { expect(page).to have_css("dt + dd", text: "") }
+    end
+  end
+end

--- a/spec/components/koi/summary_list/datetime_component_spec.rb
+++ b/spec/components/koi/summary_list/datetime_component_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Koi::SummaryList::DatetimeComponent do
+  subject(:component) { Koi::SummaryListComponent.new(model:) }
+
+  let(:model) { create(:post) }
+
+  describe "#datetime" do
+    let(:render) do
+      render_inline(component) do |dl|
+        dl.datetime(:updated_at)
+      end
+    end
+
+    before { render }
+
+    it { expect(page).to have_css("dt", text: "Updated at") }
+    it { expect(page).to have_css("dt + dd", text: I18n.l(model.updated_at, format: :admin)) }
+
+    context "with format" do
+      let(:render) do
+        render_inline(component) do |dl|
+          dl.datetime(:updated_at, format: :short)
+        end
+      end
+
+      it { expect(page).to have_css("dt + dd", text: I18n.l(model.updated_at, format: :short)) }
+    end
+
+    context "with blank" do
+      let(:model) { build(:post) }
+
+      it { expect(page).not_to have_css("dt") }
+    end
+
+    context "with blank and skip_blank: false" do
+      subject(:component) { Koi::SummaryListComponent.new(model:, skip_blank: false) }
+
+      let(:model) { build(:post) }
+
+      it { expect(page).to have_css("dt + dd", text: "") }
+    end
+  end
+end

--- a/spec/components/koi/summary_list/item_component_spec.rb
+++ b/spec/components/koi/summary_list/item_component_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# @deprecated legacy interface for Koi 4.0-era definition lists
+describe Koi::SummaryList::ItemComponent do
+  subject(:component) { Koi::SummaryListComponent.new(model:) }
+
+  let(:model) { create(:post) }
+
+  describe "#item" do
+    subject(:component) { Koi::SummaryListComponent.new(class: "item-table") }
+
+    let(:body) { ->(component) { component.item(model, :name) } }
+
+    before do
+      render_inline(component, &body)
+    end
+
+    it { expect(page).to have_css("dt", text: "Name") }
+    it { expect(page).to have_css("dt + dd", text: model.name) }
+
+    context "with empty value" do
+      let(:model) { create(:post, name: "") }
+
+      it { expect(page).not_to have_css("dt", text: "Name") }
+    end
+
+    context "with empty value and skip_blank: false on the list" do
+      subject(:component) { Koi::SummaryListComponent.new(class: "item-table", skip_blank: false) }
+
+      let(:model) { create(:post, name: "") }
+
+      it { expect(page).to have_css("dt", text: "Name") }
+      it { expect(page).to have_css("dt + dd", text: "") }
+    end
+
+    context "with empty value and skip_blank: false on the item" do
+      let(:body) { ->(component) { component.item(model, :name, skip_blank: false) } }
+
+      let(:model) { create(:post, name: "") }
+
+      it { expect(page).to have_css("dt", text: "Name") }
+      it { expect(page).to have_css("dt + dd", text: "") }
+    end
+
+    context "with custom label" do
+      let(:body) { ->(component) { component.item(model, :name, label: { text: "Custom" }) } }
+
+      it { expect(page).to have_css("dt", text: "Custom") }
+      it { expect(page).to have_css("dt + dd", text: model.name) }
+    end
+
+    context "with rich text" do
+      let(:body) { ->(component) { component.item(model, :content) } }
+
+      it { expect(page).to have_css("dt", text: "Content") }
+      it { expect(page.find("dd > div").native.to_html).to eq(model.content.to_s.strip) }
+    end
+
+    context "with a block for the value" do
+      let(:body) do
+        Proc.new do |component|
+          component.item(model, :name) do |value|
+            vc_test_controller.helpers.content_tag(:span, value)
+          end
+        end
+      end
+
+      it { expect(page).to have_css("dt", text: "Name") }
+      it { expect(page.find("dd > span").native.to_html).to eq("<span>#{model.name}</span>") }
+    end
+  end
+
+  describe "#items_with" do
+    subject(:component) { Koi::SummaryListComponent.new(class: "item-table") }
+
+    let(:body) { ->(component) { component.items_with(model:, attributes: [:name]) } }
+
+    before do
+      render_inline(component, &body)
+    end
+
+    it { expect(page).to have_css("dt", text: "Name") }
+    it { expect(page).to have_css("dt + dd", text: model.name) }
+  end
+end

--- a/spec/components/koi/summary_list/number_component_spec.rb
+++ b/spec/components/koi/summary_list/number_component_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Koi::SummaryList::NumberComponent do
+  subject(:component) { Koi::SummaryListComponent.new(model:) }
+
+  let(:model) { create(:post) }
+
+  describe "#number" do
+    let(:render) do
+      render_inline(component) do |dl|
+        dl.number(:id)
+      end
+    end
+
+    before { render }
+
+    it { expect(page).to have_css("dt", text: "Id") }
+    it { expect(page).to have_css("dt + dd", text: model.id.to_s) }
+
+    context "with blank" do
+      let(:model) { build(:post) }
+
+      it { expect(page).not_to have_css("dt") }
+    end
+
+    context "with blank and skip_blank: false on the list" do
+      subject(:component) { Koi::SummaryListComponent.new(model:, skip_blank: false) }
+
+      let(:model) { build(:post) }
+
+      it { expect(page).to have_css("dt + dd", text: "") }
+    end
+
+    context "with blank and skip_blank: false on the item" do
+      let(:model) { build(:post) }
+
+      let(:render) do
+        render_inline(component) do |dl|
+          dl.text(:id, skip_blank: false)
+        end
+      end
+
+      it { expect(page).to have_css("dt + dd", text: "") }
+    end
+  end
+end

--- a/spec/components/koi/summary_list/rich_text_component_spec.rb
+++ b/spec/components/koi/summary_list/rich_text_component_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Koi::SummaryList::RichTextComponent do
+  subject(:component) { Koi::SummaryListComponent.new(model:) }
+
+  let(:model) { create(:post) }
+
+  describe "#rich_text" do
+    before do
+      render_inline(component) do |dl|
+        dl.rich_text(:content)
+      end
+    end
+
+    it { expect(page).to have_css("dt", text: "Content") }
+    it { expect(page.find("dd > div").native.to_html).to eq(model.content.to_s.strip) }
+  end
+end

--- a/spec/components/koi/summary_list/text_component_spec.rb
+++ b/spec/components/koi/summary_list/text_component_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Koi::SummaryList::TextComponent do
+  subject(:component) { Koi::SummaryListComponent.new(model:) }
+
+  let(:model) { create(:post) }
+
+  describe "#text" do
+    let(:render) do
+      render_inline(component) do |dl|
+        dl.text(:name)
+      end
+    end
+
+    before { render }
+
+    it { expect(page).to have_css("dt", text: "Name") }
+    it { expect(page).to have_css("dt + dd", text: model.name) }
+
+    context "with blank" do
+      let(:model) { create(:post, name: "") }
+
+      it { expect(page).not_to have_css("dt") }
+    end
+
+    context "with blank and skip_blank: false on the list" do
+      subject(:component) { Koi::SummaryListComponent.new(model:, skip_blank: false) }
+
+      let(:model) { create(:post, name: "") }
+
+      it { expect(page).to have_css("dt + dd", text: model.name) }
+    end
+
+    context "with blank and skip_blank: false on the item" do
+      let(:model) { create(:post, name: "") }
+
+      let(:render) do
+        render_inline(component) do |dl|
+          dl.text(:name, skip_blank: false)
+        end
+      end
+
+      it { expect(page).to have_css("dt + dd", text: model.name) }
+    end
+
+    context "with embedded html" do
+      let(:model) { create(:post, name: "<strong>Foo</strong>") }
+
+      it { expect(page).to have_css("dt", text: "Name") }
+      it { expect(page.find("dt + dd").native.to_html).to eq("<dd>&lt;strong&gt;Foo&lt;/strong&gt;</dd>") }
+    end
+  end
+end

--- a/spec/components/koi/summary_list_component_spec.rb
+++ b/spec/components/koi/summary_list_component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Koi::SummaryListComponent do
+  subject(:component) { described_class.new(model:) }
+
+  let(:model) { create(:post) }
+
+  it "renders list" do
+    render_inline(component)
+    expect(page).to have_css("dl.summary-list")
+  end
+end

--- a/spec/generators/koi/admin_views_generator_spec.rb
+++ b/spec/generators/koi/admin_views_generator_spec.rb
@@ -31,4 +31,21 @@ RSpec.describe Koi::AdminViewsGenerator do
     expect(Pathname.new(file("app/views/admin/tests/_fields.html.erb"))).to exist
     expect(Pathname.new(file("app/views/admin/tests/_test.html+row.erb"))).to exist
   end
+
+  describe "views/admin/tests/show.html.erb" do
+    subject { file("app/views/admin/tests/show.html.erb") }
+
+    before do
+      gen = generator(%w(test title:string description:rich_text ordinal:integer archived_at:datetime active:boolean))
+      Ammeter::OutputCapturer.capture(:stdout) { gen.invoke_all }
+    end
+
+    it { is_expected.to contain "<h2>Summary</h2>" }
+    it { is_expected.to contain "<%= render Koi::SummaryListComponent.new(model: test) do |dl| %>" }
+    it { is_expected.to contain "<% dl.text :title %>" }
+    it { is_expected.to contain "<% dl.rich_text :description %>" }
+    it { is_expected.to contain "<% dl.number :ordinal %>" }
+    it { is_expected.to contain "<% dl.datetime :archived_at %>" }
+    it { is_expected.to contain "<% dl.boolean :active %>" }
+  end
 end


### PR DESCRIPTION
Update summary component for show pages to allow users to declaratively specify the types they are expecting.

Supersedes and deprecates the existing `definition_list` helper.