### PR TITLE
Spike: Use invitations to enrol new users

### DIFF
--- a/app/assets/stylesheets/koi/pages/_login.scss
+++ b/app/assets/stylesheets/koi/pages/_login.scss
@@ -10,7 +10,7 @@
 
 .admin-login > main {
   flex: 1 1 auto;
-  max-width: 20rem;
+  max-width: 30rem;
   background: white;
   border-radius: 0.25rem;
   height: unset;

--- a/app/controllers/admin/credentials_controller.rb
+++ b/app/controllers/admin/credentials_controller.rb
@@ -8,7 +8,8 @@ module Admin
 
     def new
       unless @admin_user.webauthn_id
-        @admin_user.update!(webauthn_id: WebAuthn.generate_user_id)
+        # disable validations to allow saving without password or passkey credentials
+        @admin_user.update_attribute!(:webauthn_id, WebAuthn.generate_user_id)
       end
 
       options = webauthn_relying_party.options_for_registration(
@@ -46,8 +47,8 @@ module Admin
       )
 
       respond_to do |format|
+        format.turbo_stream { render locals: { admin: @admin_user } } if self_referred?
         format.html { redirect_to admin_admin_user_path(@admin_user), status: :see_other }
-        format.turbo_stream { render locals: { admin: @admin_user } }
       end
     end
 

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -11,6 +11,8 @@ module Admin
     def new
       return redirect_to admin_dashboard_path if admin_signed_in?
 
+      return redirect_to admin_token_path(params[:token]) if params[:token].present?
+
       render :new, locals: { admin_user: Admin::User.new }
     end
 

--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Admin
+  class TokensController < ApplicationController
+    include Koi::Controller::JsonWebToken
+
+    skip_before_action :authenticate_admin, only: %i[show update]
+    before_action :set_token, only: %i[show update]
+
+    def create
+      admin = Admin::User.find(params[:id])
+      token = encode_token(admin_id: admin.id, exp: 24.hours.from_now.to_i, iat: Time.now.to_i)
+
+      render locals: { token: }
+    end
+
+    def update
+      return redirect_to admin_dashboard_path, status: :see_other if admin_signed_in?
+
+      return redirect_to new_admin_session_path, status: :see_other, notice: "invalid token" if @token.blank?
+
+      admin = Admin::User.find(@token[:admin_id])
+      sign_in_admin(admin)
+
+      case params[:commit]
+      when "passkey"
+        redirect_to new_admin_admin_user_credential_path(admin)
+      when "password"
+        redirect_to edit_admin_admin_user_path(admin)
+      else
+        redirect_to admin_admin_user_path(admin)
+      end
+    end
+
+    def show
+      return redirect_to new_admin_session_path, notice: "invalid token" if @token.blank?
+
+      admin = Admin::User.find(@token[:admin_id])
+
+      return redirect_to new_admin_session_path, notice: "token already used" if token_utilised?(admin, @token)
+
+      render locals: { admin:, token: params[:token] }, layout: "koi/login"
+    end
+
+    private
+
+    def set_token
+      @token = decode_token(params[:token])
+    end
+
+    def token_utilised?(admin, token)
+      admin.current_sign_in_at.present? || (admin.last_sign_in_at.present? && admin.last_sign_in_at.to_i > token[:iat])
+    end
+
+    def sign_in_admin(admin)
+      admin.current_sign_in_at = Time.current
+      admin.current_sign_in_ip = request.remote_ip
+      admin.sign_in_count      = 1
+
+      # disable validations to allow saving without password or passkey credentials
+      admin.save!(validate: false)
+      session[:admin_user_id] = admin.id
+    end
+  end
+end

--- a/app/controllers/concerns/koi/controller/json_web_token.rb
+++ b/app/controllers/concerns/koi/controller/json_web_token.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Koi
+  module Controller
+    module JsonWebToken
+      extend ActiveSupport::Concern
+
+      SECRET_KEY = Rails.application.secret_key_base
+
+      def encode_token(**payload)
+        JWT.encode(payload, SECRET_KEY)
+      end
+
+      def decode_token(token)
+        payload = JWT.decode(token, SECRET_KEY)[0]
+        HashWithIndifferentAccess.new(payload)
+      rescue JWT::DecodeError
+        nil
+      end
+    end
+  end
+end

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -2,12 +2,12 @@
   <%= render Koi::Header::ShowComponent.new(resource: admin) %>
 <% end %>
 
-<%= definition_list(class: "item-table") do |builder| %>
-  <%= builder.item admin, :name %>
-  <%= builder.item admin, :email %>
-  <%= builder.item admin, :created_at %>
-  <%= builder.item admin, :last_sign_in_at, label: { text: "Last sign in" } %>
-  <%= builder.item admin, :archived? %>
+<%= render Koi::SummaryListComponent.new(model: admin, class: "item-table") do |builder| %>
+  <%= builder.text :name %>
+  <%= builder.text :email %>
+  <%= builder.datetime :created_at %>
+  <%= builder.datetime :last_sign_in_at, label: { text: "Last sign in" } %>
+  <%= builder.boolean :archived? %>
 <% end %>
 
 <div class="actions">
@@ -17,6 +17,7 @@
                   method: :delete,
                   form:   { data: { turbo_confirm: "Are you sure?" } } %>
   <% end %>
+  <%= button_to "Invite", invite_admin_admin_user_path(admin), class: "button button--primary", form: { id: "invite" } %>
 </div>
 
 <h2>Authentication</h2>

--- a/app/views/admin/tokens/create.turbo_stream.erb
+++ b/app/views/admin/tokens/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "invite" do %>
+  <%= text_field_tag :invite_link, new_admin_session_url(token: url_encode(token)), readonly: true %>
+<% end %>

--- a/app/views/admin/tokens/show.html.erb
+++ b/app/views/admin/tokens/show.html.erb
@@ -1,0 +1,13 @@
+<%= render "layouts/koi/navigation_header" %>
+
+<%= form_with(model: admin, url: accept_admin_admin_user_path(admin), method: :post) do |form| %>
+  <%= tag.input name: :token, type: :hidden, value: token %>
+  <%= form.govuk_fieldset legend: { text: 'Sign up to admin terminal' }, id: "signup-fields" do %>
+    <%= form.govuk_email_field :email, readonly: true %>
+    <%= form.govuk_text_field :name, readonly: true %>
+  <% end %>
+  <div class="actions-group">
+    <%= form.admin_save "Signup with passkey", value: :passkey, data: { turbo_frame: "kpop" } %>
+    <%= form.admin_save "Signup with password", value: :password %>
+  </div>
+<% end %>

--- a/app/views/layouts/koi/login.html.erb
+++ b/app/views/layouts/koi/login.html.erb
@@ -23,7 +23,14 @@
 </head>
 <body class="admin-login">
 <main class="stack">
+  <div>
+    <%= render "layouts/koi/flash" unless flash.empty? %>
+  </div>
   <%= yield %>
 </main>
+<%= render ScrimComponent.new %>
+<%= render Kpop::FrameComponent.new do %>
+  <%= content_for :kpop %>
+<% end %>
 </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,13 @@ Rails.application.routes.draw do
     resources :url_rewrites
     resources :admin_users do
       resources :credentials, only: %i[new create destroy]
+      post :invite, on: :member, to: "tokens#create"
+      post :accept, on: :member, to: "tokens#update"
     end
+
+    # JWT tokens have dots(represents the 3 parts of data) in them, so we need to allow them in the URL
+    # can by pass if we use token as a query param
+    get "token/:token", to: "tokens#show", as: :token, token: /[^\/]+/
 
     resource :cache, only: %i[destroy]
     resource :dashboard, only: %i[show]

--- a/spec/requests/admin/sessions_controller_spec.rb
+++ b/spec/requests/admin/sessions_controller_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Admin::SessionsController do
       action
       expect(response).to have_http_status(:success)
     end
+
+    context "with token" do
+      let(:token) { "token" }
+      let(:action) { get new_admin_session_path, params: { token: } }
+
+      it "redirects to the token path" do
+        action
+        expect(response).to redirect_to(admin_token_path(token))
+      end
+    end
   end
 
   describe "POST /admin/sessions" do

--- a/spec/requests/admin/tokens_controller_spec.rb
+++ b/spec/requests/admin/tokens_controller_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::TokensController do
+  subject { action && response }
+
+  def jwt_token(**payload)
+    JWT.encode(payload, Rails.application.secret_key_base)
+  end
+
+  describe "GET /admin/token/:token" do
+    let(:action) { get admin_token_path(token) }
+    let(:admin) { create(:admin, password: "") }
+    let(:token) { jwt_token(admin_id: admin.id, exp: 5.seconds.from_now.to_i, iat: Time.now.to_i) }
+
+    it { is_expected.to be_successful }
+
+    context "with used token" do
+      let(:admin) { create(:admin, last_sign_in_at: Time.now) }
+      let(:token) { jwt_token(admin_id: admin.id, exp: 5.seconds.from_now.to_i, iat: 1.hour.ago.to_i) }
+
+      it { is_expected.to redirect_to(new_admin_session_path) }
+
+      it "shows a flash message" do
+        action
+        expect(flash[:notice]).to match(/token already used/)
+      end
+    end
+
+    context "with invalid token" do
+      let(:token) { "token" }
+
+      it { is_expected.to redirect_to(new_admin_session_path) }
+
+      it "shows a flash message" do
+        action
+        expect(flash[:notice]).to match(/invalid token/)
+      end
+    end
+  end
+
+  describe "POST /admin/admin_users/:id/invite" do
+    let(:action) { post invite_admin_admin_user_path(admin), as: :turbo_stream }
+    let(:admin) { create(:admin) }
+
+    include_context "with admin session"
+
+    it_behaves_like "requires admin"
+
+    it { is_expected.to be_successful }
+
+    it "renders the token" do
+      action
+      expect(response.body).to have_css("turbo-stream[action=replace][target='invite']")
+    end
+  end
+
+  describe "POST /admin/admin_users/:id/accept" do
+    let(:action) { post accept_admin_admin_user_path(admin), params: { commit:, token: } }
+    let(:admin) { create(:admin, password: "") }
+    let(:commit) { "commit" }
+    let(:token) { jwt_token(admin_id: admin.id, exp: 5.seconds.from_now.to_i, iat: Time.now.to_i) }
+
+    it { is_expected.to redirect_to(admin_admin_user_path(admin)) }
+
+    it "updates the admin login details" do
+      expect { action }.to change { admin.reload.current_sign_in_at }.from(nil).to be_present
+    end
+
+    context "when admin is signed in" do
+      let(:admin) { create(:admin) }
+
+      include_context "with admin session"
+
+      it { is_expected.to redirect_to(admin_dashboard_path) }
+    end
+  end
+end

--- a/spec/system/admin/invitation_spec.rb
+++ b/spec/system/admin/invitation_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "admin/invites" do
+  def encode_token(**args)
+    JWT.encode(args, Rails.application.secret_key_base)
+  end
+
+  it "creates an invitation" do
+    admin = create(:admin)
+    visit "/admin"
+
+    fill_in "Email", with: admin.email
+    fill_in "Password", with: admin.password
+    click_on "Log in"
+
+    visit "/admin/admin_users/new"
+
+    fill_in "Email", with: "john.doe@gmail.com"
+    fill_in "Name", with: "John Doe"
+
+    click_button "Save"
+
+    expect(page).to have_css("button", text: "Invite")
+
+    click_button "Invite"
+
+    expect(page).to have_css("input[type=text][value*=token]")
+  end
+
+  it "can accept an invitation and signup with password" do
+    admin = create(:admin, password: "")
+    token = encode_token(admin_id: admin.id, exp: 1.hour.from_now.to_i, ist: Time.now.to_i)
+
+    visit "admin/session/new?token=#{token}"
+
+    expect(page).to have_content(/Sign up to admin terminal/)
+
+    click_button "Signup with password"
+
+    expect(page).to have_css("input[type=password]")
+
+    fill_in "Password", with: "password"
+
+    click_button "Save"
+
+    expect(page).to have_content(admin.email)
+
+    click_link "Dashboard"
+
+    expect(page).to have_current_path("/admin/dashboard")
+  end
+
+  it "can accept an invitation and signup with passkey" do
+    admin = create(:admin, password: "")
+    token = encode_token(admin_id: admin.id, exp: 1.hour.from_now.to_i, ist: Time.now.to_i)
+
+    visit "admin/session/new?token=#{token}"
+
+    expect(page).to have_content(/Sign up to admin terminal/)
+
+    click_button "Signup with passkey"
+
+    expect(page).to have_current_path(new_admin_admin_user_credential_path(admin))
+    within("#kpop") do |kpop|
+      expect(kpop).to have_content("Register device")
+    end
+  end
+end


### PR DESCRIPTION
* Adds new endpoint to handle JWT tokens
* Enables generating invitation link to share from admin user show page
* Adds a signup page using token details and confirmation to enrol new admin
* updates validations on password

**Admin show -> invite**
![Screenshot 2024-03-06 at 9 20 03 am](https://github.com/katalyst/koi/assets/100643476/8b779657-d948-4093-ad6d-b02cade34cfc)

**Admin show -> invite link**
![Screenshot 2024-03-06 at 9 20 18 am](https://github.com/katalyst/koi/assets/100643476/39cf6ace-194f-4549-958a-6b27935cdbcb)

**Token show**
<img width="793" alt="Screenshot 2024-03-06 at 9 25 03 am" src="https://github.com/katalyst/koi/assets/100643476/d405861e-050c-42b5-9ab8-b25cc195aaf9">


