### PR TITLE
Fix for editing settings with simple form and rails 7.1 (Koi 2.6)

### DIFF
--- a/app/controllers/koi/settings_controller.rb
+++ b/app/controllers/koi/settings_controller.rb
@@ -17,9 +17,12 @@ module Koi
     end
 
     def update_multiple
-      params[:setting][:setting].each do |id, _value|
-        @setting = Setting.find(id.to_i)
-        @setting.update(params[:setting][:setting][id])
+      params[:setting].each do |key, data|
+        setting_id = key.delete_prefix("setting_")
+        next unless /\A\d+\z/.match?(setting_id)
+
+        @setting = Setting.find(setting_id.to_i)
+        @setting.update(value: data[:value])
       end
 
       params[:group] = "main" if params[:group].blank?

--- a/app/views/koi/settings/_field_boolean.html.erb
+++ b/app/views/koi/settings/_field_boolean.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :boolean, wrapper: :checkbox, label: label, hint: hint, wrapper_html: { class: "checkbox__single" } %>
+<%= f.input attr, as: :boolean, wrapper: :checkbox, label: label, hint: hint, input_html: { value: value }, wrapper_html: { class: "checkbox__single" } %>

--- a/app/views/koi/settings/_field_check_boxes.html.erb
+++ b/app/views/koi/settings/_field_check_boxes.html.erb
@@ -1,6 +1,6 @@
 <% data = object.data_source.call if object.data_source %>
 <% if data.nil? %>
-  <%= f.input :serialized_value, :as => :check_boxes, label: label, hint: hint %>
+  <%= f.input :serialized_value, :as => :check_boxes, label: label, hint: hint, input_html: { value: value } %>
 <% else %>
   <%= f.input :serialized_value, :as => :check_boxes, collection: data, label: label, hint: hint %>
 <% end %>

--- a/app/views/koi/settings/_field_dynamic.html.erb
+++ b/app/views/koi/settings/_field_dynamic.html.erb
@@ -1,8 +1,8 @@
 <%=
   begin
-    render "field_#{f.object.field_type}", :f => f, :attr => attr, object: f.object, label: attr, hint: hint
+    render "field_#{f.object.field_type}", :f => f, :attr => attr, object: f.object, label: attr, hint: hint, value: value
   rescue ActionView::MissingTemplate
-    render "field_string", :f => f, :attr => attr, object: f.object, label: attr, hint: hint
+    render "field_string", :f => f, :attr => attr, object: f.object, label: attr, hint: hint, value: value
   end
 %>
 <% if !current_admin.god? && !f.object.hint.blank? %>

--- a/app/views/koi/settings/_field_file.html.erb
+++ b/app/views/koi/settings/_field_file.html.erb
@@ -63,35 +63,3 @@
   </div>
 
 </div>
-
-<!-- kept in case any of the above doesn't work for settings -->
-<!--
-<%= f.label(label) %>
-
-<div class="media">
-  <% if !is_nil_or_new %>
-    <%= attachment_image_tag(value, class: "media-object pull-left") %>
-  <% else %>
-    <%= placeholder_image_tag("No File", size: "100x100", class: "media-object pull-left") %>
-  <% end %>
-  <div class="media-body">
-    <% unless is_nil_or_new %>
-      <p><%= link_to "View #{kind}", value.url, :target => "_blank" %></p>
-    <% end %>
-
-      <%= fields_for "setting[setting[#{object.id}]]" do |setting| %>
-        <div class="controls">
-        <% if !is_nil_or_new %>
-            <label class="radio"><%= setting.radio_button :remove_file, false, checked: !is_nil_or_new %> Keep this <%= kind %></label>
-            <label class="radio"><%= setting.radio_button :remove_file, true %> Remove this <%= kind %></label>
-        <% end %>
-
-        <label class="radio"><%= setting.radio_button :remove_file, false, checked: is_nil_or_new, id: html_id %> Upload a new <%= kind %></label>
-
-        <%= setting.file_field :file, label: false, onclick: "document.getElementById('#{html_id}').click()" %>
-      <% end %>
-
-    </div>
-  </div>
-</div>
--->

--- a/app/views/koi/settings/_field_radio.html.erb
+++ b/app/views/koi/settings/_field_radio.html.erb
@@ -1,6 +1,6 @@
 <% data = object.data_source.call if object.data_source %>
 <% if data.nil? %>
-  <%= f.input attr.to_sym, :as => :radio_buttons, label: label, hint: hint %>
+  <%= f.input attr.to_sym, :as => :radio_buttons, label: label, hint: hint, input_html: { value: value } %>
 <% else %>
   <%= f.input attr.to_sym, :as => :radio_buttons, collection: data, label: label, hint: hint %>
 <% end %>

--- a/app/views/koi/settings/_field_rich_text.html.erb
+++ b/app/views/koi/settings/_field_rich_text.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :text, label: label, hint: hint, input_html: { class: "wysiwyg source" } %>
+<%= f.input attr, as: :text, label: label, hint: hint, input_html: { value: value, class: "wysiwyg source" } %>

--- a/app/views/koi/settings/_field_select.html.erb
+++ b/app/views/koi/settings/_field_select.html.erb
@@ -1,6 +1,6 @@
 <% data = object.data_source.call if object.data_source %>
 <% if data.nil? %>
-  <%= f.input attr, as: :string, label: label, hint: hint, input_html: { class: "form--medium" } %>
+  <%= f.input attr, as: :string, label: label, hint: hint, input_html: { value: value, class: "form--medium" } %>
 <% else %>
   <%= f.input attr.to_sym, :as => :select, collection: data, label: label, hint: hint, input_html: { class: "form--medium" } %>
 <% end %>

--- a/app/views/koi/settings/_field_string.html.erb
+++ b/app/views/koi/settings/_field_string.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :string, label: label, hint: hint, input_html: { class: "form--medium" } %>
+<%= f.input attr, as: :string, label: label, hint: hint, input_html: { value: value, class: "form--medium" } %>

--- a/app/views/koi/settings/_field_text.html.erb
+++ b/app/views/koi/settings/_field_text.html.erb
@@ -1,1 +1,1 @@
-<%= f.input attr, as: :text, label: label, hint: hint, input_html: { class: "form--large" } %>
+<%= f.input attr, as: :text, label: label, hint: hint, input_html: { value: value, class: "form--large" } %>

--- a/app/views/koi/settings/_form_fields.html.erb
+++ b/app/views/koi/settings/_form_fields.html.erb
@@ -3,7 +3,7 @@
   <% hint = f.hint(attr) || false %>
   <% if attr == :value %>
     <% f.object.derive_data_source(collection: true) %>
-    <%= render "field_#{klass.crud.find(:fields, attr, :type)}", f: f, attr: attr, object: f.object, label: :value, hint: hint %>
+    <%= render "field_#{klass.crud.find(:fields, attr, :type)}", f: f, attr: attr, object: f.object, label: :value, hint: hint, value: f.object.value %>
   <% else %>
     <%=
       assoc    = klass.reflect_on_association(attr)

--- a/app/views/koi/settings/_settings_form.html.erb
+++ b/app/views/koi/settings/_settings_form.html.erb
@@ -2,7 +2,7 @@
   <%- next if object.role.eql?("Super") && !current_admin.god? -%>
   <% field = object['field_type'] if Setting::FIELD_TYPES.values.include? object['field_type'] %>
   <% field ||= 'string' %>
-  <%= f.simple_fields_for "setting[#{object.id}]", object do |setting| %>
-    <%= render "/koi/settings/field_#{field}", object: object, f: setting, attr: :value, hint: object.hint, label: object.label %>
+  <%= f.simple_fields_for "setting_#{object.id}" do |setting| %>
+    <%= render "/koi/settings/field_#{field}", object: object, f: setting, attr: :value, hint: object.hint, label: object.label, value: object.value %>
   <% end %>
 <% end %>


### PR DESCRIPTION
related to https://github.com/heartcombo/simple_form/issues/1834 The previous html for editing a setting looked like this:

```
<input class="string optional form--medium enhanced" type="text" name="setting[setting[36086]][value]" id="setting_setting_70243__value">
```

it now looks like:
```
<input value="Job position" class="string required form--medium enhanced" type="text" name="setting[setting_36086][value]" id="setting_setting_36086_value">
```