### PR TITLE
Fix: named route helpers when viewing mounted engines

### DIFF
--- a/app/views/layouts/koi/_navigation_header.html.erb
+++ b/app/views/layouts/koi/_navigation_header.html.erb
@@ -2,7 +2,7 @@
   <h2 class="site-name"><%= URI.parse(root_url).host %></h2>
   <%# show username on nav header and Koi Admin on login page %>
   <% if local_assigns[:admin].present? %>
-    <%= link_to admin.name, admin_admin_user_path(admin), class: "admin-name" %>
+    <%= link_to admin.name, main_app.admin_admin_user_path(admin), class: "admin-name" %>
   <% else %>
     <h3 class="admin-name">Koi Admin</h3>
   <% end %>


### PR DESCRIPTION
When viewing the navigation module (Navigation Engine) it could not resolve the `admin_admin_user_path`. 
Using `main_app` allows both the mounted engines (navigation, content) and koi to resolve the `admin_admin_user_path` correctly