### PR TITLE
Allow accept attribute override via mime_types keyword argument

### DIFF
--- a/config/initializers/navigation.rb
+++ b/config/initializers/navigation.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-Katalyst::Navigation.config.base_controller = "Admin::ApplicationController"
+Katalyst::Navigation.config.base_controller  = "Admin::ApplicationController"
 Katalyst::Navigation.config.errors_component = "Koi::Navigation::Editor::ErrorsComponent"

--- a/lib/govuk_design_system_formbuilder/elements/document.rb
+++ b/lib/govuk_design_system_formbuilder/elements/document.rb
@@ -7,7 +7,7 @@ module GOVUKDesignSystemFormBuilder
     class Document < Base
       include FileElement
 
-      MIME_TYPES            = %w[
+      MIME_TYPES = %w[
         image/png image/gif image/jpeg image/webp
         application/pdf audio/*
       ].freeze
@@ -15,7 +15,7 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @mime_types      = MIME_TYPES || kwargs[:mime_types]
+        @mime_types      = kwargs.fetch(:mime_types, MIME_TYPES)
         @label           = label
         @caption         = caption
         @hint            = hint
@@ -29,7 +29,7 @@ module GOVUKDesignSystemFormBuilder
         add_option(options, :class, "preview-file")
         add_option(options, :class, "hidden") unless preview?
 
-        tag.div **options do
+        tag.div(**options) do
           filename = @builder.object.send(@attribute_name).filename.to_s
           tag.p(filename, class: "preview-filename") + destroy_element_trigger
         end


### PR DESCRIPTION
Resolves https://github.com/katalyst/koi/issues/590

I note that we also do not have any tests for these custom elements. This would be something to consider, too.