### PR TITLE
Index search - clobbering as you typed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,8 +99,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ammeter (1.1.7)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -177,13 +177,13 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.27.1-aarch64-linux)
+    google-protobuf (4.27.2-aarch64-linux)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.1-arm64-darwin)
+    google-protobuf (4.27.2-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.1-x86_64-linux)
+    google-protobuf (4.27.2-x86_64-linux)
       bigdecimal
       rake (>= 13)
     govuk_design_system_formbuilder (5.4.0)
@@ -208,30 +208,30 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.7.2)
-    jwt (2.8.1)
+    jwt (2.8.2)
       base64
     katalyst-basic-auth (0.5.0)
       rack
-    katalyst-content (2.4.1)
+    katalyst-content (2.4.2)
       active_storage_validations
       katalyst-html-attributes
       katalyst-kpop
       view_component
-    katalyst-govuk-formbuilder (1.9.3)
+    katalyst-govuk-formbuilder (1.9.4)
       govuk_design_system_formbuilder
     katalyst-html-attributes (1.1.0)
       activesupport
       html-attributes-utils
-    katalyst-kpop (3.1.2)
+    katalyst-kpop (3.1.3)
       katalyst-html-attributes
       turbo-rails
       view_component
-    katalyst-navigation (1.8.0)
+    katalyst-navigation (1.8.1)
       katalyst-html-attributes
       katalyst-kpop
       katalyst-tables
       view_component
-    katalyst-tables (3.1.0)
+    katalyst-tables (3.3.1)
       katalyst-html-attributes
       view_component
     language_server-protocol (3.17.0.3)
@@ -248,9 +248,9 @@ GEM
     method_source (1.1.0)
     mini_magick (4.13.1)
     mini_mime (1.1.5)
-    minitest (5.23.1)
+    minitest (5.24.0)
     mutex_m (0.2.0)
-    net-imap (0.4.13)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -269,7 +269,7 @@ GEM
     openssl (3.2.0)
     openssl-signature_algorithm (1.3.0)
       openssl (> 2.0)
-    pagy (8.4.4)
+    pagy (8.5.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -281,11 +281,11 @@ GEM
       railties (>= 7.0.0)
     psych (5.1.2)
       stringio
-    public_suffix (5.1.1)
+    public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
-    rack (3.1.3)
+    rack (3.1.4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -336,7 +336,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
-    rexml (3.3.0)
+    rexml (3.3.1)
       strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
@@ -346,7 +346,7 @@ GEM
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (6.1.2)
+    rspec-rails (6.1.3)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
@@ -407,10 +407,10 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.5-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
-    sentry-rails (5.17.3)
+    sentry-rails (5.18.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.17.3)
-    sentry-ruby (5.17.3)
+      sentry-ruby (~> 5.18.0)
+    sentry-ruby (5.18.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (6.2.0)

--- a/app/helpers/koi/index_actions_helper.rb
+++ b/app/helpers/koi/index_actions_helper.rb
@@ -71,7 +71,7 @@ module Koi
       form.search_field(:search,
                         placeholder: t("koi.labels.search", default: "Search"),
                         value:       params[:search],
-                        data:        { index_actions_target: "search" })
+                        data:        { index_actions_target: "search", turbo_permanent: "" })
     end
 
     def links(form, &)

--- a/spec/system/index/filtering_spec.rb
+++ b/spec/system/index/filtering_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "index/filtering" do
       page.go_back
 
       expect(page).to have_current_path("/admin/posts?search=#{query}")
-      expect(page).to have_css("input[type=search][value=#{query}]")
+      expect(find("input[type=search][name=search]").value).to eql(query)
     end
   end
 end


### PR DESCRIPTION
If you typed while the response of the search is being rendered turbo morph would clobber your input field to display what was sent to the server, not your latest changes. Marking the input field as permanent ensures the user can continue typing.