### PR TITLE
Test that the model instance is deleted in the destroy method

### DIFF
--- a/lib/generators/koi/admin_controller/templates/controller_spec.rb.tt
+++ b/lib/generators/koi/admin_controller/templates/controller_spec.rb.tt
@@ -124,12 +124,17 @@ RSpec.describe <%= controller_class_name %>Controller do
 
   describe "DELETE /admin/<%= plural_name %>/:id" do
     let(:action) { delete polymorphic_path([:admin, model]) }
+    let!(:model) { create(:<%= singular_name %>) }
 
     it_behaves_like "requires admin"
 
     it "renders successfully" do
       action
       expect(response).to redirect_to(polymorphic_path([:admin, <%= class_name %>]))
+    end
+
+    it "deletes the <%= singular_name %>" do
+      expect { action }.to change(<%= class_name %>, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
The generated spec for the destroy method only tests the redirect, not the actual model deletion. To do this, we need to ensure that the model is instantiated before performing the action.