### PR TITLE
Save navigation menu on edit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    katalyst-koi (5.0.1)
+    katalyst-koi (5.0.2)
       bcrypt
       importmap-rails
       katalyst-content (>= 3.0.0.alpha.1)

--- a/app/views/katalyst/navigation/menus/edit.html.erb
+++ b/app/views/katalyst/navigation/menus/edit.html.erb
@@ -15,5 +15,5 @@
   <%= form.govuk_text_field :title %>
   <%= form.govuk_text_field :slug %>
   <%= form.govuk_text_field :depth %>
-  <%= form.button(type: :submit, class: "button") %>
+  <%= form.button(type: :submit, class: "button", name: :commit, value: :save) %>
 <% end %>

--- a/katalyst-koi.gemspec
+++ b/katalyst-koi.gemspec
@@ -3,7 +3,7 @@
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "katalyst-koi"
-  s.version     = "5.0.1"
+  s.version     = "5.0.2"
   s.authors     = ["Katalyst Interactive"]
   s.email       = ["developers@katalyst.com.au"]
 


### PR DESCRIPTION
Removal of `admin_save` caused the button to not have a `commit` param, skipping the save of the menu.