### PR TITLE
Fix redirect in auth local admin

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -97,8 +97,11 @@ module Admin
     def authenticate_local_admin
       return if admin_signed_in? || !Rails.env.development?
 
-      session[:admin_user_id] =
-        Admin::User.where(email: %W[#{ENV.fetch('USER', nil)}@katalyst.com.au admin@katalyst.com.au]).first&.id
+      @current_admin_user = Admin::User.find_by(email: "#{ENV.fetch('USER', nil)}@katalyst.com.au")
+
+      return unless admin_signed_in?
+
+      session[:admin_user_id] = current_admin_user.id
 
       flash.delete(:redirect) if (redirect = flash[:redirect])
 


### PR DESCRIPTION
If a local admin user was not found, do not redirect back to dashboard. Otherwise there is an infinite loop from dashboard to new session if there are no local admin configured.