### PR TITLE
Use ActionController::Base for well-knowns

### DIFF
--- a/app/controllers/well_knowns_controller.rb
+++ b/app/controllers/well_knowns_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WellKnownsController < ApplicationController
+class WellKnownsController < ActionController::Base
   before_action :set_well_known
 
   attr_reader :well_known


### PR DESCRIPTION
rationale: ApplicationController may contain logic that is undesirable for serving well-known files. e.g. user authentication