### PR TITLE
Rework admin sessions following rails authentication guidelines

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -93,8 +93,6 @@ module Admin
 
       attribute :name, :string
       attribute :email, :string
-      attribute :last_sign_in_at, :date
-      attribute :last_sign_out_at, :date
       attribute :sign_in_count, :integer
       attribute :password_login, :enum, scope: :has_password_login, multiple: false
       attribute :passkey, :boolean, scope: :has_passkey

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -70,10 +70,7 @@ module Admin
       # assume that the previous step injected the user's ID into the session and remove it regardless of outcome
       admin_user = Admin::User.find_by(id: session.delete(:pending_admin_user_id))
 
-      if admin_user&.otp&.verify(session_params[:token],
-                                 drift_ahead:  15,
-                                 drift_behind: 15,
-                                 after:        admin_user.current_sign_in_at)
+      if admin_user&.otp&.verify(session_params[:token], drift_ahead: 15, drift_behind: 15)
         admin_sign_in(admin_user)
       else
         admin_user = Admin::User.new

--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -22,6 +22,9 @@ module Admin
 
     def update
       if (@admin_user = Admin::User.find_by_token_for(:password_reset, params[:token]))
+        # Treat token-based recovery sign-in as a password reset boundary and
+        # revoke other browser sessions before issuing a fresh one.
+        admin_user.sessions.destroy_all
         create_admin_session!(admin_user)
 
         if admin_user.credentials.any?

--- a/app/controllers/concerns/koi/controller/has_admin_users.rb
+++ b/app/controllers/concerns/koi/controller/has_admin_users.rb
@@ -25,7 +25,7 @@ module Koi
       alias_method :current_admin, :current_admin_user
 
       def requires_session_authentication!
-        head(:forbidden) if session[:admin_user_id].blank?
+        head(:forbidden) if Koi::Current.admin_session.blank?
       end
 
       module Test

--- a/app/controllers/concerns/koi/controller/has_admin_users.rb
+++ b/app/controllers/concerns/koi/controller/has_admin_users.rb
@@ -8,6 +8,7 @@ module Koi
       included do
         helper_method :admin_signed_in?
         helper_method :current_admin_user
+        before_action :set_koi_admin_session, unless: :koi_admin_controller?
 
         # @deprecated use current admin user instead
         helper_method :current_admin
@@ -19,6 +20,16 @@ module Koi
 
       def current_admin_user
         Koi::Current.admin_user
+      end
+
+      def set_koi_admin_session
+        return if Koi::Current.admin_session.present? || Koi::Current.admin_user.present?
+
+        Koi::Current.admin_session = Admin::Session.from_request(request)
+      end
+
+      def koi_admin_controller?
+        self.class < Admin::ApplicationController
       end
 
       # @deprecated Use current_admin_user instead

--- a/app/controllers/concerns/koi/controller/records_authentication.rb
+++ b/app/controllers/concerns/koi/controller/records_authentication.rb
@@ -6,14 +6,7 @@ module Koi
       ADMIN_SESSION_COOKIE = :koi_admin_session_id
 
       def create_admin_session!(admin_user = Koi::Current.admin_user)
-        sign_in_at = Time.current
-
-        update_last_sign_in(admin_user)
-
-        admin_user.current_sign_in_at = sign_in_at
-        admin_user.current_sign_in_ip = request.remote_ip
         admin_user.sign_in_count += 1
-
         admin_user.save!
 
         Koi::Current.admin_session = admin_user.sessions.create!(
@@ -28,32 +21,11 @@ module Koi
         }
       end
 
-      def destroy_admin_session!(admin_user = Koi::Current.admin_user)
+      def destroy_admin_session!
         Koi::Current.admin_session&.destroy!
         Koi::Current.admin_session = nil
 
         cookies.delete(ADMIN_SESSION_COOKIE)
-
-        return unless admin_user
-
-        sign_out_at = Time.current
-
-        update_last_sign_in(admin_user)
-
-        admin_user.last_sign_out_at = sign_out_at
-        admin_user.current_sign_in_at = nil
-        admin_user.current_sign_in_ip = nil
-
-        admin_user.save!
-      end
-
-      private
-
-      def update_last_sign_in(admin_user)
-        return if admin_user.current_sign_in_at.blank?
-
-        admin_user.last_sign_in_at = admin_user.current_sign_in_at
-        admin_user.last_sign_in_ip = admin_user.current_sign_in_ip
       end
     end
   end

--- a/app/controllers/concerns/koi/controller/records_authentication.rb
+++ b/app/controllers/concerns/koi/controller/records_authentication.rb
@@ -3,6 +3,8 @@
 module Koi
   module Controller
     module RecordsAuthentication
+      ADMIN_SESSION_COOKIE = :koi_admin_session_id
+
       def create_admin_session!(admin_user = Koi::Current.admin_user)
         sign_in_at = Time.current
 
@@ -14,13 +16,23 @@ module Koi
 
         admin_user.save!
 
-        session[:admin_user_id] = admin_user.id
-        session[:admin_user_signed_in_at] = sign_in_at.iso8601
+        Koi::Current.admin_session = admin_user.sessions.create!(
+          ip_address: request.remote_ip,
+          user_agent: request.user_agent,
+        )
+
+        cookies.signed.permanent[ADMIN_SESSION_COOKIE] = {
+          value:     Koi::Current.admin_session.id,
+          httponly:  true,
+          same_site: :lax,
+        }
       end
 
       def destroy_admin_session!(admin_user = Koi::Current.admin_user)
-        session[:admin_user_id] = nil
-        session[:admin_user_signed_in_at] = nil
+        Koi::Current.admin_session&.destroy!
+        Koi::Current.admin_session = nil
+
+        cookies.delete(ADMIN_SESSION_COOKIE)
 
         return unless admin_user
 

--- a/app/controllers/concerns/koi/controller/records_authentication.rb
+++ b/app/controllers/concerns/koi/controller/records_authentication.rb
@@ -3,8 +3,6 @@
 module Koi
   module Controller
     module RecordsAuthentication
-      ADMIN_SESSION_COOKIE = :koi_admin_session_id
-
       def create_admin_session!(admin_user = Koi::Current.admin_user)
         admin_user.sign_in_count += 1
         admin_user.save!
@@ -14,7 +12,7 @@ module Koi
           user_agent: request.user_agent,
         )
 
-        cookies.signed.permanent[ADMIN_SESSION_COOKIE] = {
+        cookies.signed.permanent[Admin::Session::COOKIE_NAME] = {
           value:     Koi::Current.admin_session.id,
           httponly:  true,
           same_site: :lax,
@@ -24,8 +22,9 @@ module Koi
       def destroy_admin_session!
         Koi::Current.admin_session&.destroy!
         Koi::Current.admin_session = nil
+        Koi::Current.admin_user    = nil
 
-        cookies.delete(ADMIN_SESSION_COOKIE)
+        cookies.delete(Admin::Session::COOKIE_NAME)
       end
     end
   end

--- a/app/models/admin/session.rb
+++ b/app/models/admin/session.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Admin
+  # Persists browser authentication state for an admin user.
+  class Session < ApplicationRecord
+    self.table_name = :admin_sessions
+
+    belongs_to :admin, class_name: "Admin::User", inverse_of: :sessions
+  end
+end

--- a/app/models/admin/session.rb
+++ b/app/models/admin/session.rb
@@ -3,8 +3,20 @@
 module Admin
   # Persists browser authentication state for an admin user.
   class Session < ApplicationRecord
+    COOKIE_NAME = :koi_admin_session_id
+
     self.table_name = :admin_sessions
 
     belongs_to :admin, class_name: "Admin::User", inverse_of: :sessions
+
+    def self.from_request(request)
+      session_id = request.cookie_jar.signed[COOKIE_NAME]
+      return if session_id.blank?
+
+      admin_session = includes(:admin).find_by(id: session_id)
+      return if admin_session&.admin.blank?
+
+      admin_session
+    end
   end
 end

--- a/app/models/admin/user.rb
+++ b/app/models/admin/user.rb
@@ -14,8 +14,8 @@ module Admin
     # disable validations for password_digest
     has_secure_password validations: false
 
-    generates_token_for(:api_access, expires_in: 12.hours) { current_sign_in_at }
-    generates_token_for(:password_reset, expires_in: 30.minutes) { current_sign_in_at }
+    generates_token_for(:api_access, expires_in: 12.hours)
+    generates_token_for(:password_reset, expires_in: 30.minutes)
 
     has_many :credentials, inverse_of: :admin, class_name: "Admin::Credential", dependent: :destroy
     has_many :sessions, inverse_of: :admin, class_name: "Admin::Session", dependent: :destroy

--- a/app/models/admin/user.rb
+++ b/app/models/admin/user.rb
@@ -18,6 +18,7 @@ module Admin
     generates_token_for(:password_reset, expires_in: 30.minutes) { current_sign_in_at }
 
     has_many :credentials, inverse_of: :admin, class_name: "Admin::Credential", dependent: :destroy
+    has_many :sessions, inverse_of: :admin, class_name: "Admin::Session", dependent: :destroy
 
     attribute :password_login, :string
     enum :password_login, { none: "none", password_only: "password_only", mfa: "mfa" }, prefix: true
@@ -77,6 +78,11 @@ module Admin
       else
         :mfa
       end
+    end
+
+    def archive
+      sessions.destroy_all
+      super
     end
 
     def to_s

--- a/app/models/koi/current.rb
+++ b/app/models/koi/current.rb
@@ -2,7 +2,14 @@
 
 module Koi
   class Current < ActiveSupport::CurrentAttributes
-    # @return [Admin::User]
+    # @return [Admin::Session,nil]
+    attribute :admin_session
+
+    # @return [Admin::User,nil]
     attribute :admin_user
+
+    def admin_user
+      super || admin_session&.admin
+    end
   end
 end

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -19,11 +19,11 @@
   <% row.select %>
   <% row.link :name, url: :admin_admin_user_path %>
   <% row.text :email %>
+  <% row.text :sign_in_count, label: "Sign-ins" %>
   <% row.enum :password_login, label: "Password" %>
   <% row.boolean :credentials, label: "Passkey" do |cell| %>
     <%= cell.value.any? ? "Yes" : "No" %>
   <% end %>
-  <% row.date :last_sign_in_at, label: "Last active" %>
 <% end %>
 
 <%= table_pagination_with(collection:) %>

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -19,7 +19,7 @@
   <% row.text :name %>
   <% row.text :email %>
   <% row.date :created_at %>
-  <% row.date :last_sign_in_at, label: "Last access" %>
+  <% row.text :sign_in_count, label: "Sign-ins" %>
   <% row.boolean :passkey %>
   <% row.boolean :otp, label: "MFA" %>
   <% row.boolean :archived? %>

--- a/app/views/admin/profiles/show.html.erb
+++ b/app/views/admin/profiles/show.html.erb
@@ -12,7 +12,7 @@
   <% row.text :name %>
   <% row.text :email %>
   <% row.date :created_at %>
-  <% row.date(:last_sign_in_at, label: "Last access") %>
+  <% row.text :sign_in_count, label: "Sign-ins" %>
   <% row.boolean :passkey %>
   <% row.boolean(:otp, label: "MFA") do |otp| %>
     <span class="repel">

--- a/db/migrate/20260514120000_create_admin_sessions.rb
+++ b/db/migrate/20260514120000_create_admin_sessions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateAdminSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :admin_sessions do |t|
+      t.references :admin, null: false, foreign_key: { to_table: :admins }
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260514153000_remove_legacy_auth_columns_from_admins.rb
+++ b/db/migrate/20260514153000_remove_legacy_auth_columns_from_admins.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveLegacyAuthColumnsFromAdmins < ActiveRecord::Migration[8.0]
+  def change
+    change_table :admins, bulk: true do |t|
+      t.remove :current_sign_in_at, type: :datetime
+      t.remove :current_sign_in_ip, type: :string
+      t.remove :last_sign_in_at, type: :datetime
+      t.remove :last_sign_in_ip, type: :string
+      t.remove :last_sign_out_at, type: :datetime
+    end
+  end
+end

--- a/docs/content.md
+++ b/docs/content.md
@@ -240,7 +240,7 @@ Koi.
           end
      
           def admin?
-            request.session[:admin_user_id].present?
+            Admin::Session.from_request(request).present?
           end
      
           def page
@@ -258,6 +258,8 @@ Koi.
 
     - **Verification:** visit the public page and confirm blocks render respecting heading styles, themes, and
       visibility toggles. The status bar’s “Published/Preview” links should now resolve without overrides.
+    - **Public controller auth helpers:** if your public controller needs `admin_signed_in?` or `current_admin_user`,
+      include `Koi::Controller::HasAdminUsers`. The concern hydrates admin state automatically for non-Koi-admin controllers.
     - **Need root-level slugs?** Follow the [`root-level-page-routing.md`](./root-level-page-routing.md) pattern to
       serve published pages at `/slug` while keeping previews admin-only.
 

--- a/docs/root-level-page-routing.md
+++ b/docs/root-level-page-routing.md
@@ -91,7 +91,7 @@ class PagesController < ApplicationController
 
     def action = request.params[:action]
 
-    def admin? = request.session[:admin_user_id].present?
+    def admin? = Admin::Session.from_request(request).present?
 
     def page
       return unless request.params[:slug] && request.get?
@@ -106,7 +106,7 @@ Highlights:
 - The constraint only runs for GET requests with a `slug` param, letting other verbs fall through.
 - Matched pages are cached on the request, so the controller, SEO helpers, and downstream services (e.g. layout components) share one lookup.
 - `match?` returns `false` when no page is found or when a non-admin requests a preview, letting the router continue to the next route.
-- `admin?` piggybacks on the `admin_user_id` session that Koi already sets when an admin is signed in.
+- `admin?` resolves Koi's persisted admin session from the signed admin session cookie.
 - `preview` redirects to `show` when the page is already published, ensuring canonical URLs.
 - The `seo_metadatum` pass-through demonstrates how additional controller actions can reuse the cached page without hitting the database again.
 
@@ -116,6 +116,7 @@ Highlights:
 - **Slug uniqueness** – ensure the `pages` table validates and indexes `slug` uniqueness; otherwise collisions produce confusing fallbacks.
 - **Route ordering** – keep explicit static routes (`get "/health"`) above the constraint block. Anything defined below may never run because the constraint claims the slug first.
 - **Preview access** – verify that admin authentication is in place (via `Koi.config.authenticate_local_admins` or real login) before relying on previews.
+- **Public controller checks** – if the controller itself needs `admin_signed_in?`, include `Koi::Controller::HasAdminUsers`. The concern hydrates `Koi::Current.admin_user` automatically for non-Koi-admin controllers.
 - **Caching hooks** – if you add middleware or helpers that assume `request.page`, use the header set in `match?` to avoid duplicate queries.
 - **Specs** – cover `GET /:slug` for published pages, `GET /:slug/preview` for admins, and missing slugs falling through to a 404.
 
@@ -128,4 +129,3 @@ This approach works for any single module that owns the remaining root paths—s
 - update `resolve("ModelName")` accordingly so polymorphic helpers stay correct.
 
 If you genuinely need multiple modules sharing the root namespace, consider a dispatcher that inspects the slug format or a database-backed router instead of duplicating this constraint class.
-

--- a/lib/koi/middleware/admin_authentication.rb
+++ b/lib/koi/middleware/admin_authentication.rb
@@ -2,6 +2,7 @@
 
 module Koi
   module Middleware
+    # Authenticates admin requests via bearer token or persisted browser session.
     class AdminAuthentication
       def initialize(app)
         @app = app
@@ -15,30 +16,30 @@ module Koi
         end
       end
 
+      # Handles authentication for admin requests and clears invalid session cookies.
+      # @param env [Hash]
+      # @return [Array(Integer, Hash, #each)]
       def admin_call(env)
-        request = ActionDispatch::Request.new(env)
-        session = ActionDispatch::Request::Session.find(request)
+        request           = ActionDispatch::Request.new(env)
+        cookie_session_id = request.cookie_jar.signed[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE]
 
         # Always retrieve user to ensure we are not vulnerable to timing attacks
-        Koi::Current.admin_user = if bearer_token(request).present?
-                                    bearer_admin_user(request)
-                                  else
-                                    session_admin_user(session)
-                                  end
+        auth_strategy = authenticate_request(request, cookie_session_id)
 
-        # Remove from session if not found
-        if session.has_key?(:admin_user_id) && !authenticated?
-          session.delete(:admin_user_id)
-          session.delete(:admin_user_signed_in_at)
-        end
+        response = if requires_authentication?(request) && !authenticated?
+                     unauthorized_response(request)
+                   else
+                     @app.call(env)
+                   end
 
-        if requires_authentication?(request) && !authenticated?
-          unauthorized_response(request)
+        if invalid_admin_cookie?(cookie_session_id, auth_strategy)
+          clear_admin_cookie(request, response)
         else
-          @app.call(env)
+          response
         end
       ensure
-        Koi::Current.admin_user = nil
+        Koi::Current.admin_session = nil
+        Koi::Current.admin_user    = nil
       end
 
       private
@@ -60,23 +61,55 @@ module Koi
         Admin::User.find_by_token_for(:api_access, token)
       end
 
-      def session_admin_user(session)
-        admin_user = Admin::User.find_by(id: session[:admin_user_id])
-        return unless admin_user
-
-        signed_in_at = session_signed_in_at(session)
-        return if signed_in_at.blank?
-        return if admin_user.last_sign_out_at.present? && signed_in_at < admin_user.last_sign_out_at
-
-        admin_user
+      # Authenticates the request and records which auth strategy was used.
+      # @param request [ActionDispatch::Request]
+      # @param cookie_session_id [String, nil]
+      # @return [Symbol] `:bearer` when the Authorization header was used,
+      #   `:cookie` when the signed admin session cookie was used.
+      def authenticate_request(request, cookie_session_id)
+        if bearer_token(request).present?
+          Koi::Current.admin_user = bearer_admin_user(request)
+          :bearer
+        else
+          Koi::Current.admin_session = cookie_admin_session(cookie_session_id)
+          :cookie
+        end
       end
 
-      def session_signed_in_at(session)
-        Time.zone.parse(session[:admin_user_signed_in_at].to_s)
-      rescue ArgumentError
-        nil
+      # Determines whether an admin session cookie should be cleared.
+      # @param cookie_session_id [String, nil]
+      # @param auth_strategy [Symbol]
+      # @return [Boolean]
+      def invalid_admin_cookie?(cookie_session_id, auth_strategy)
+        auth_strategy == :cookie && cookie_session_id.present? && Koi::Current.admin_session.blank?
       end
 
+      # Writes a deleted admin session cookie to the Rack response.
+      # @param request [ActionDispatch::Request]
+      # @param response [Array(Integer, Hash, #each)]
+      # @return [Array(Integer, Hash, #each)]
+      def clear_admin_cookie(request, response)
+        request.cookie_jar.delete(Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE)
+        rack_response = Rack::Response.new(response[2], response[0], response[1])
+        request.cookie_jar.write(rack_response)
+        rack_response.finish
+      end
+
+      # Loads the persisted admin session referenced by the signed cookie.
+      # @param session_id [String, nil]
+      # @return [Admin::Session, nil]
+      def cookie_admin_session(session_id)
+        return if session_id.blank?
+
+        admin_session = Admin::Session.includes(:admin).find_by(id: session_id)
+        return if admin_session&.admin.blank?
+
+        admin_session
+      end
+
+      # Extracts a bearer token from the Authorization header.
+      # @param request [ActionDispatch::Request]
+      # @return [String, nil]
       def bearer_token(request)
         return nil if request.authorization.blank?
 

--- a/lib/koi/middleware/admin_authentication.rb
+++ b/lib/koi/middleware/admin_authentication.rb
@@ -21,10 +21,10 @@ module Koi
       # @return [Array(Integer, Hash, #each)]
       def admin_call(env)
         request           = ActionDispatch::Request.new(env)
-        cookie_session_id = request.cookie_jar.signed[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE]
+        cookie_session_id = request.cookie_jar.signed[Admin::Session::COOKIE_NAME]
 
         # Always retrieve user to ensure we are not vulnerable to timing attacks
-        auth_strategy = authenticate_request(request, cookie_session_id)
+        auth_strategy = authenticate_request(request)
 
         response = if requires_authentication?(request) && !authenticated?
                      unauthorized_response(request)
@@ -63,15 +63,14 @@ module Koi
 
       # Authenticates the request and records which auth strategy was used.
       # @param request [ActionDispatch::Request]
-      # @param cookie_session_id [String, nil]
       # @return [Symbol] `:bearer` when the Authorization header was used,
       #   `:cookie` when the signed admin session cookie was used.
-      def authenticate_request(request, cookie_session_id)
+      def authenticate_request(request)
         if bearer_token(request).present?
           Koi::Current.admin_user = bearer_admin_user(request)
           :bearer
         else
-          Koi::Current.admin_session = cookie_admin_session(cookie_session_id)
+          Koi::Current.admin_session = Admin::Session.from_request(request)
           :cookie
         end
       end
@@ -89,22 +88,10 @@ module Koi
       # @param response [Array(Integer, Hash, #each)]
       # @return [Array(Integer, Hash, #each)]
       def clear_admin_cookie(request, response)
-        request.cookie_jar.delete(Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE)
+        request.cookie_jar.delete(Admin::Session::COOKIE_NAME)
         rack_response = Rack::Response.new(response[2], response[0], response[1])
         request.cookie_jar.write(rack_response)
         rack_response.finish
-      end
-
-      # Loads the persisted admin session referenced by the signed cookie.
-      # @param session_id [String, nil]
-      # @return [Admin::Session, nil]
-      def cookie_admin_session(session_id)
-        return if session_id.blank?
-
-        admin_session = Admin::Session.includes(:admin).find_by(id: session_id)
-        return if admin_session&.admin.blank?
-
-        admin_session
       end
 
       # Extracts a bearer token from the Authorization header.

--- a/lib/tasks/dummy.thor
+++ b/lib/tasks/dummy.thor
@@ -76,8 +76,8 @@ class Dummy < Thor
       $LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)
     RUBY
 
-    # Remove Koi migrations that will be loaded directly from Koi
-    run "rm -f spec/dummy/db/migrate/*.koi.rb"
+    remove_copied_koi_migrations
+    remove_stale_dummy_schema
 
     reset_database(migrate: true)
 
@@ -173,6 +173,27 @@ class Dummy < Thor
       awk '{print "spec/dummy/" $2}'|
       xargs erblint -a
     SH
+  end
+
+  # Remove copied Koi migrations from the dummy app so `app:db:migrate`
+  # only runs the engine migrations once.
+  def remove_copied_koi_migrations
+    migration_names = Dir.glob(File.expand_path("../../db/migrate/*.rb", __dir__)).map do |file|
+      migration_name(file)
+    end
+
+    Dir.glob(File.join(destination_root, "db/migrate/*.rb")).each do |file|
+      File.delete(file) if migration_names.include?(migration_name(file))
+    end
+  end
+
+  def remove_stale_dummy_schema
+    schema_path = File.join(destination_root, "db/schema.rb")
+    File.delete(schema_path) if File.exist?(schema_path) # rubocop:disable Lint/NonAtomicFileOperation
+  end
+
+  def migration_name(file)
+    File.basename(file).sub(/^\d+_/, "").sub(/(?:\.[^.]+)?\.rb$/, "")
   end
 end
 

--- a/spec/models/admin/session_spec.rb
+++ b/spec/models/admin/session_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Session do
+  describe ".from_request" do
+    subject(:admin_session) { described_class.from_request(request) }
+
+    let(:request) { ActionDispatch::TestRequest.create }
+
+    context "with a valid admin session cookie" do
+      let!(:session_record) { admin.sessions.create!(ip_address: "127.0.0.1", user_agent: "RSpec") }
+      let(:admin) { create(:admin) }
+
+      before do
+        request.cookie_jar.signed[described_class::COOKIE_NAME] = session_record.id
+      end
+
+      it { is_expected.to eq(session_record) }
+    end
+
+    context "with no admin session cookie" do
+      it { is_expected.to be_nil }
+    end
+
+    context "with a deleted admin session" do
+      before do
+        request.cookie_jar.signed[described_class::COOKIE_NAME] = 999_999
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/admin/user_spec.rb
+++ b/spec/models/admin/user_spec.rb
@@ -88,13 +88,21 @@ RSpec.describe Admin::User do
         expect(described_class.find_by_token_for(:api_access, token)).to be_nil
       end
     end
+  end
 
-    it "is invalidated when current_sign_in_at changes" do
-      token = admin.generate_token_for(:api_access)
+  describe "password reset tokens" do
+    it "is valid immediately after issuance" do
+      token = admin.generate_token_for(:password_reset)
 
-      admin.update!(current_sign_in_at: 1.second.from_now)
+      expect(described_class.find_by_token_for(:password_reset, token)).to eq(admin)
+    end
 
-      expect(described_class.find_by_token_for(:api_access, token)).to be_nil
+    it "is rejected after 30 minutes" do
+      token = admin.generate_token_for(:password_reset)
+
+      travel 30.minutes + 1.second do
+        expect(described_class.find_by_token_for(:password_reset, token)).to be_nil
+      end
     end
   end
 end

--- a/spec/models/admin/user_spec.rb
+++ b/spec/models/admin/user_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Admin::User do
   it { is_expected.to validate_presence_of(:email) }
 
   it { is_expected.to have_many(:credentials).class_name("Admin::Credential").dependent(:destroy) }
+  it { is_expected.to have_many(:sessions).class_name("Admin::Session").dependent(:destroy) }
 
   it { is_expected.to allow_values("a@b.com").for(:email) }
   it { is_expected.not_to allow_values("@b.com", "fail").for(:email) }
@@ -59,6 +60,17 @@ RSpec.describe Admin::User do
 
     it "returns :mfa when password_digest and otp_secret are set" do
       expect(create(:admin).password_login).to eq(:mfa)
+    end
+  end
+
+  describe "#archive!" do
+    before do
+      admin.sessions.create!(ip_address: "127.0.0.1", user_agent: "RSpec")
+      admin.sessions.create!(ip_address: "127.0.0.2", user_agent: "RSpec")
+    end
+
+    it "destroys persisted sessions" do
+      expect { admin.archive! }.to change { admin.sessions.count }.from(2).to(0)
     end
   end
 

--- a/spec/requests/admin/admin_users_controller_spec.rb
+++ b/spec/requests/admin/admin_users_controller_spec.rb
@@ -187,6 +187,12 @@ RSpec.describe Admin::AdminUsersController do
       expect { action }.to(change { Admin::User.archived.count }.to(2))
     end
 
+    it "destroys persisted sessions for archived admins" do
+      admins.each { |admin| admin.sessions.create!(ip_address: "127.0.0.1", user_agent: "RSpec") }
+
+      expect { action }.to change(Admin::Session, :count).by(-2)
+    end
+
     it_behaves_like "with bearer token authentication" do
       it "fails with an authentication error" do
         put(archive_admin_admin_users_path, headers:, params:)
@@ -233,6 +239,12 @@ RSpec.describe Admin::AdminUsersController do
 
     it "archives the admin" do
       expect { action }.to change { admin_user.reload.archived }.to(true)
+    end
+
+    it "destroys persisted sessions for the archived admin" do
+      admin_user.sessions.create!(ip_address: "127.0.0.1", user_agent: "RSpec")
+
+      expect { action }.to change(Admin::Session, :count).by(-1)
     end
 
     context "when the admin is archived" do

--- a/spec/requests/admin/authentication_spec.rb
+++ b/spec/requests/admin/authentication_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "admin authentication" do
 
       it "does not create a session" do
         action
-        expect(session[:admin_user_id]).to be_nil
+        expect(Admin::Session.count).to eq(0)
       end
 
       it "is rejected after the admin signs in again" do
@@ -39,47 +39,66 @@ RSpec.describe "admin authentication" do
       end
     end
 
+    context "with a valid bearer token and valid admin session cookie" do
+      let(:admin) { create(:admin) }
+      let(:action) do
+        get "/admin/dashboard", headers: { "Authorization" => "Bearer #{admin.generate_token_for(:api_access)}" }
+      end
+
+      include_context "with admin session"
+
+      it "does not clear the admin session cookie" do
+        action
+
+        expect(Array(response.headers["Set-Cookie"]).join("\n")).not_to include(
+          "#{Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE}=;",
+        )
+      end
+    end
+
     context "with an invalid bearer token" do
       let(:action) { get "/admin/dashboard", headers: { "Authorization" => "Bearer invalid" } }
 
       it { is_expected.to have_http_status(:unauthorized) }
     end
 
-    context "with an expired session" do
+    context "with a deleted admin session" do
       let(:admin) { create(:admin) }
 
       include_context "with admin session"
 
       before do
-        admin.update!(last_sign_out_at: Time.current)
+        admin.sessions.sole.destroy!
       end
 
       it { is_expected.to have_http_status(:see_other).and(redirect_to("/admin/session/new")) }
 
-      it "clears the admin session" do
+      it "clears the admin session cookie" do
         action
-        aggregate_failures do
-          expect(session[:admin_user_id]).to be_nil
-          expect(session[:admin_user_signed_in_at]).to be_nil
-        end
+
+        expect(Array(response.headers["Set-Cookie"]).join("\n")).to include(
+          "#{Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE}=",
+        )
       end
     end
 
-    context "with a session missing its sign in timestamp" do
+    context "with an archived admin user session" do
+      let(:admin) { create(:admin) }
+
       include_context "with admin session"
 
       before do
-        allow_any_instance_of(Koi::Middleware::AdminAuthentication).to receive(:session_signed_in_at).and_return(nil)
+        admin.archive!
       end
 
       it { is_expected.to have_http_status(:see_other).and(redirect_to("/admin/session/new")) }
 
-      it "clears the admin session" do
+      it "clears the admin session cookie" do
         action
-        aggregate_failures do
-          expect(session[:admin_user_id]).to be_nil
-          expect(session[:admin_user_signed_in_at]).to be_nil
-        end
+
+        expect(Array(response.headers["Set-Cookie"]).join("\n")).to include(
+          "#{Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE}=",
+        )
       end
     end
   end

--- a/spec/requests/admin/authentication_spec.rb
+++ b/spec/requests/admin/authentication_spec.rb
@@ -28,15 +28,6 @@ RSpec.describe "admin authentication" do
         action
         expect(Admin::Session.count).to eq(0)
       end
-
-      it "is rejected after the admin signs in again" do
-        token = admin.generate_token_for(:api_access)
-        admin.update!(current_sign_in_at: 1.second.from_now)
-
-        get "/admin/dashboard", headers: { "Authorization" => "Bearer #{token}" }
-
-        expect(response).to have_http_status(:unauthorized)
-      end
     end
 
     context "with a valid bearer token and valid admin session cookie" do

--- a/spec/requests/admin/authentication_spec.rb
+++ b/spec/requests/admin/authentication_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "admin authentication" do
         action
 
         expect(Array(response.headers["Set-Cookie"]).join("\n")).not_to include(
-          "#{Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE}=;",
+          "#{Admin::Session::COOKIE_NAME}=;",
         )
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe "admin authentication" do
         action
 
         expect(Array(response.headers["Set-Cookie"]).join("\n")).to include(
-          "#{Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE}=",
+          "#{Admin::Session::COOKIE_NAME}=",
         )
       end
     end
@@ -88,7 +88,7 @@ RSpec.describe "admin authentication" do
         action
 
         expect(Array(response.headers["Set-Cookie"]).join("\n")).to include(
-          "#{Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE}=",
+          "#{Admin::Session::COOKIE_NAME}=",
         )
       end
     end

--- a/spec/requests/admin/sessions_controller_spec.rb
+++ b/spec/requests/admin/sessions_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Admin::SessionsController do
         post admin_session_path, params: { admin: { email: admin.email } }, as: :turbo_stream
         post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }, as: :turbo_stream
 
-        expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to be_present
+        expect(cookies[Admin::Session::COOKIE_NAME.to_s]).to be_present
       end
     end
 
@@ -162,7 +162,7 @@ RSpec.describe Admin::SessionsController do
         create_credential
         action
 
-        expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to be_present
+        expect(cookies[Admin::Session::COOKIE_NAME.to_s]).to be_present
       end
 
       it "updates login metadata" do
@@ -204,7 +204,7 @@ RSpec.describe Admin::SessionsController do
     it "clears the admin session cookie" do
       action
 
-      expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to eq("")
+      expect(cookies[Admin::Session::COOKIE_NAME.to_s]).to eq("")
     end
 
     it "only destroys the current persisted session" do

--- a/spec/requests/admin/sessions_controller_spec.rb
+++ b/spec/requests/admin/sessions_controller_spec.rb
@@ -78,9 +78,11 @@ RSpec.describe Admin::SessionsController do
     it "accepts otp and updates login metadata" do
       expect do
         post admin_session_path, params: { admin: { email: admin.email } }, as: :turbo_stream
-        post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }, as: :turbo_stream
+        post admin_session_path,
+             params: { admin: { email: admin.email, password: admin.password } },
+             as:     :turbo_stream
         post admin_session_path, params: { admin: { token: admin.otp.now } }, as: :turbo_stream
-      end.to(change { admin.reload.current_sign_in_at })
+      end.to(change { admin.reload.sign_in_count }.by(1))
     end
 
     context "with no otp present" do
@@ -165,7 +167,7 @@ RSpec.describe Admin::SessionsController do
 
       it "updates login metadata" do
         create_credential
-        expect { action }.to(change { admin.reload.current_sign_in_at })
+        expect { action }.to(change { admin.reload.sign_in_count }.by(1))
       end
 
       it "updates credential count" do
@@ -205,8 +207,10 @@ RSpec.describe Admin::SessionsController do
       expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to eq("")
     end
 
-    it "updates logout metadata" do
-      expect { action }.to change { admin.reload.last_sign_out_at }.from(nil).to be_present
+    it "only destroys the current persisted session" do
+      admin.sessions.create!(ip_address: "127.0.0.2", user_agent: "Other Session")
+
+      expect { action }.to change { admin.reload.sessions.count }.from(2).to(1)
     end
   end
 end

--- a/spec/requests/admin/sessions_controller_spec.rb
+++ b/spec/requests/admin/sessions_controller_spec.rb
@@ -92,13 +92,21 @@ RSpec.describe Admin::SessionsController do
         expect(response).to have_http_status(:see_other).and(redirect_to(admin_dashboard_path))
       end
 
-      it "creates the admin session with timestamp" do # rubocop:disable RSpec/ExampleLength
+      it "creates the persisted admin session" do
+        post admin_session_path, params: { admin: { email: admin.email } }, as: :turbo_stream
+
+        expect do
+          post admin_session_path,
+               params: { admin: { email: admin.email, password: admin.password } },
+               as:     :turbo_stream
+        end.to change { admin.sessions.count }.by(1)
+      end
+
+      it "sets the admin session cookie" do
         post admin_session_path, params: { admin: { email: admin.email } }, as: :turbo_stream
         post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }, as: :turbo_stream
-        aggregate_failures do
-          expect(session[:admin_user_id]).to eq(admin.id)
-          expect(session[:admin_user_signed_in_at]).to be_present
-        end
+
+        expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to be_present
       end
     end
 
@@ -142,10 +150,17 @@ RSpec.describe Admin::SessionsController do
         expect(response).to redirect_to(admin_dashboard_path)
       end
 
-      it "creates the admin session" do
+      it "creates the persisted admin session" do
+        create_credential
+
+        expect { action }.to change { admin.sessions.count }.by(1)
+      end
+
+      it "sets the admin session cookie" do
         create_credential
         action
-        expect(session[:admin_user_id]).to be_present
+
+        expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to be_present
       end
 
       it "updates login metadata" do
@@ -177,12 +192,17 @@ RSpec.describe Admin::SessionsController do
       expect(response).to redirect_to(new_admin_session_path)
     end
 
-    it "destroys the admin session" do
+    it "destroys the persisted admin session" do
+      current_session = admin.sessions.sole
       action
-      aggregate_failures do
-        expect(session[:admin_user_id]).to be_nil
-        expect(session[:admin_user_signed_in_at]).to be_nil
-      end
+
+      expect(Admin::Session.find_by(id: current_session.id)).to be_nil
+    end
+
+    it "clears the admin session cookie" do
+      action
+
+      expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to eq("")
     end
 
     it "updates logout metadata" do

--- a/spec/requests/admin/tokens_controller_spec.rb
+++ b/spec/requests/admin/tokens_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::TokensController do
     it "sets the admin session cookie" do
       action
 
-      expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to be_present
+      expect(cookies[Admin::Session::COOKIE_NAME.to_s]).to be_present
     end
 
     context "with invalid token" do

--- a/spec/requests/admin/tokens_controller_spec.rb
+++ b/spec/requests/admin/tokens_controller_spec.rb
@@ -28,22 +28,6 @@ RSpec.describe Admin::TokensController do
 
     it { is_expected.to be_successful }
 
-    context "with a consumed token" do
-      before do
-        # force token generation
-        token
-        # simulate sign-in after token creation
-        admin.update(current_sign_in_at: 1.second.from_now)
-      end
-
-      it { is_expected.to redirect_to(new_admin_session_path) }
-
-      it "shows a flash message" do
-        action
-        expect(flash[:notice]).to match(/Token invalid or consumed already/)
-      end
-    end
-
     context "with invalid token" do
       let(:token) { "token" }
 
@@ -63,8 +47,8 @@ RSpec.describe Admin::TokensController do
 
     it { is_expected.to redirect_to(new_admin_profile_credential_path) }
 
-    it "updates the admin login details" do
-      expect { action }.to change { admin.reload.current_sign_in_at }.from(nil).to be_present
+    it "increments sign in count" do
+      expect { action }.to change { admin.reload.sign_in_count }.by(1)
     end
 
     it "creates the persisted admin session" do
@@ -86,22 +70,6 @@ RSpec.describe Admin::TokensController do
       action
 
       expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to be_present
-    end
-
-    context "with a consumed token" do
-      before do
-        # force token generation
-        token
-        # simulate sign-in after token creation
-        admin.update(current_sign_in_at: 1.second.from_now)
-      end
-
-      it { is_expected.to redirect_to(new_admin_session_path) }
-
-      it "shows a flash message" do
-        action
-        expect(flash[:notice]).to match(/Token invalid or consumed already/)
-      end
     end
 
     context "with invalid token" do

--- a/spec/requests/admin/tokens_controller_spec.rb
+++ b/spec/requests/admin/tokens_controller_spec.rb
@@ -67,12 +67,25 @@ RSpec.describe Admin::TokensController do
       expect { action }.to change { admin.reload.current_sign_in_at }.from(nil).to be_present
     end
 
-    it "creates the admin session with timestamp" do
-      action
-      aggregate_failures do
-        expect(session[:admin_user_id]).to eq(admin.id)
-        expect(session[:admin_user_signed_in_at]).to be_present
+    it "creates the persisted admin session" do
+      expect { action }.to change { admin.sessions.count }.by(1)
+    end
+
+    context "with existing persisted sessions" do
+      before do
+        admin.sessions.create!(ip_address: "127.0.0.1", user_agent: "Old Session")
+        admin.sessions.create!(ip_address: "127.0.0.2", user_agent: "Older Session")
       end
+
+      it "replaces previous persisted sessions" do
+        expect { action }.to change { admin.sessions.count }.from(2).to(1)
+      end
+    end
+
+    it "sets the admin session cookie" do
+      action
+
+      expect(cookies[Koi::Controller::RecordsAuthentication::ADMIN_SESSION_COOKIE.to_s]).to be_present
     end
 
     context "with a consumed token" do


### PR DESCRIPTION
Moves admin browser authentication to persisted session records backed by a signed cookie.
based on https://guides.rubyonrails.org/security.html