### PR TITLE
KID-392: Display only the exception class in the Error column for failed background jobs

### DIFF
--- a/app/models/background_job.rb
+++ b/app/models/background_job.rb
@@ -76,6 +76,10 @@ class BackgroundJob
     "#{failure.exception_class}: #{failure.message}"
   end
 
+  def failure_class
+    failed_execution.exception_class
+  end
+
   def state
     if finished?
       :finished

--- a/app/views/admin/background_jobs/failed.html.erb
+++ b/app/views/admin/background_jobs/failed.html.erb
@@ -19,7 +19,7 @@
   <% row.text(:queue_name, label: "Queue") %>
   <% row.datetime(:updated_at, label: "Last failed") %>
   <% row.text(:error, label: "Error") do %>
-    <%= BackgroundJob.new(job).failure_reason %>
+    <%= BackgroundJob.new(job).failure_class %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
https://katalyst.atlassian.net/browse/KID-392

I tried adjusting the error column width, but long error message made the rows very tall. So, I've decided to display only the exception class in the table as the full message is already available on the show page.